### PR TITLE
Add libyaml as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/libyaml"]
+	path = deps/libyaml
+	url = https://github.com/yaml/libyaml

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,32 @@
+ATTRIBUTIONS
+
+The following software was used in making Zowe Launcher. Each piece of software is listed by name, version, website if known, and associated copyright text.
+
+
+----------------------------------------
+LibYAML version 0.2.5
+
+
+Copyright:
+
+Copyright (c) 2017-2020 Ingy döt Net
+Copyright (c) 2006-2016 Kirill Simonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -23,8 +23,9 @@ CFLAGS = -O -D_OPEN_THREADS -D_XOPEN_SOURCE=600 \
          "-Wc,langlvl(EXTC99),float(HEX),agg,list(),so(),search(),lp64,xplink" \
          "-Wc,goff,xref,gonum,roconst,gonum,asm,asmlib('SYS1.MACLIB'),asmlib('CEE.SCEEMAC')" \
          -I . \
+         -I ../deps/libyaml/include \
 
-LDFLAGS =
+LDFLAGS = -L../deps/libyaml/lib
 export _C89_LSYSLIB=CEE.SCEELKEX:CEE.SCEELKED:SYS1.CSSLIB:CSF.SCSFMOD0
 
 # C source
@@ -35,18 +36,25 @@ OBJS = $(SRCS:%.c=%.o)
 # disable built-in rules
 MAKEFLAGS += --no-builtin-rules
 
+LIBYAML = ../deps/libyaml
+LIBYAMLA = ../deps/libyaml/lib/libyaml.a
+
 all: $(LAUNCHER_TARGET)
 
-$(LAUNCHER_TARGET): main.o
+$(LAUNCHER_TARGET): $(OBJS) $(LIBYAMLA)
 	mkdir -p $(dir $(LAUNCHER_TARGET))
-	$(LD) $(LDFLAGS) -o $(LAUNCHER_TARGET) $^ || { $(RM) $@; exit 1; }
+	$(LD) $(LDFLAGS) -o $(LAUNCHER_TARGET) $(OBJS) -lyaml || { $(RM) $@; exit 1; }
 	# cp -X $(LAUNCHER_TARGET) "//'${USER}.DEV.LOADLIB(ZWELNCH)'"
 
 %.o: %.c
 	$(CC) $(CFLAGS) -o $@ -c $<
 
-.PHONY: clean
+$(LIBYAMLA):
+	cp Makefile-yaml ../deps/libyaml/Makefile
+	$(MAKE) -C $(LIBYAML)
+
+.PHONY: clean libyaml
 clean:
 	$(RM) $(LAUNCHER_TARGET)
 	$(RM) $(OBJS) $(notdir $(OBJS:%.o=%.lst))
-
+	$(MAKE) -C $(LIBYAML) clean

--- a/src/Makefile-yaml
+++ b/src/Makefile-yaml
@@ -1,0 +1,32 @@
+################################################################################
+#  This program and the accompanying materials are
+#  made available under the terms of the Eclipse Public License v2.0 which accompanies
+#  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Copyright Contributors to the Zowe Project.
+################################################################################
+
+CC:=xlclang
+MAJOR:=0
+MINOR:=2
+PATCH:=5
+ENHANCED_ASCII:=-qascii -D_ENHANCED_ASCII_EXT=0xFFFFFFFF
+VERSION:=\"$(MAJOR).$(MINOR).$(PATCH)\"
+DEFINES:=-DYAML_VERSION_MAJOR=$(MAJOR) -DYAML_VERSION_MINOR=$(MINOR) -DYAML_VERSION_PATCH=$(PATCH) -DYAML_VERSION_STRING=$(VERSION)
+CC_FLAGS:=-I./include -I./src -D_XOPEN_SOURCE_EXTENDED=1 $(DEFINES) $(ENHANCED_ASCII)
+LIBYAMLA:=lib/libyaml.a
+
+OBJS:=api.o reader.o scanner.o parser.o loader.o writer.o emitter.o dumper.o
+all:	$(LIBYAMLA)
+
+$(LIBYAMLA):	$(OBJS)
+	mkdir -p $(dir $(LIBYAMLA))
+	ar rcs $@ $^
+
+%.o:	src/%.c
+	$(CC) $(CC_FLAGS) -c $<	
+
+clean:	
+	rm -f $(LIBYAMLA) *.o


### PR DESCRIPTION
### Add libYAML to Zowe Launcher

As Zowe Launcher needs an ability to read manifest.yaml files, this PR adds libYAML to the project.