### PR TITLE
//*RPTOPTS(ON) after DD will cause JCL error

### DIFF
--- a/samplib/ZWESLSTC
+++ b/samplib/ZWESLSTC
@@ -31,9 +31,7 @@
 //SYSPRINT DD   SYSOUT=*
 //SYSERR   DD   SYSOUT=*
 //CEEOPTS  DD  *
-//*RPTOPTS(ON)
 POSIX(ON)
-/*
 //STDENV   DD  *
 INSTANCE_DIR=#instance_dir
 /*


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>