### PR TITLE
Initialize stdin manually

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -244,7 +244,7 @@ static int init_context(int argc, char **argv, const struct zl_config_t *cfg) {
   INFO(MSG_INST_DIR, zl_context.instance_dir);
 
   char stdin_file[PATH_MAX] = {0};
-  snprintf (stdin_file, sizeof(stdin_file), "%s/launcher.stdin.txt", zl_context.instance_dir);
+  snprintf (stdin_file, sizeof(stdin_file), "%s/workspace/launcher.stdin.txt", zl_context.instance_dir);
   FILE *stdin_fp = fopen(stdin_file, "w");
   if (!stdin_fp) {
     ERROR(MSG_STDIN_ERROR, stdin_file, strerror(errno));

--- a/src/main.c
+++ b/src/main.c
@@ -243,6 +243,15 @@ static int init_context(int argc, char **argv, const struct zl_config_t *cfg) {
   setenv("INSTANCE_DIR", zl_context.instance_dir, 1);
   INFO(MSG_INST_DIR, zl_context.instance_dir);
 
+  char stdin_file[PATH_MAX] = {0};
+  snprintf (stdin_file, sizeof(stdin_file), "%s/launcher.stdin.txt", zl_context.instance_dir);
+  FILE *stdin_fp = fopen(stdin_file, "w");
+  if (!stdin_fp) {
+    ERROR(MSG_STDIN_ERROR, stdin_file, strerror(errno));
+    return -1;
+  }
+  fclose(stdin_fp);
+  stdin = fopen(stdin_file, "r");
   return 0;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -247,11 +247,16 @@ static int init_context(int argc, char **argv, const struct zl_config_t *cfg) {
   snprintf (stdin_file, sizeof(stdin_file), "%s/workspace/launcher.stdin.txt", zl_context.instance_dir);
   FILE *stdin_fp = fopen(stdin_file, "w");
   if (!stdin_fp) {
-    ERROR(MSG_STDIN_ERROR, stdin_file, strerror(errno));
+    ERROR(MSG_STDIN_CREATE_ERROR, stdin_file, strerror(errno));
     return -1;
   }
   fclose(stdin_fp);
-  stdin = fopen(stdin_file, "r");
+  stdin_fp = fopen(stdin_file, "r");
+  if (!stdin_fp) {
+    ERROR(MSG_STDIN_OPEN_ERROR, stdin_file, strerror(errno));
+    return -1;
+  }
+  stdin = stdin_fp;
   return 0;
 }
 

--- a/src/msg.h
+++ b/src/msg.h
@@ -68,7 +68,8 @@
 #define MSG_NOT_ALL_STARTED     MSG_PREFIX "0052W" " not all components started\n"
 #define MSG_NOT_ALL_STOPPED     MSG_PREFIX "0053W" " not all components stopped\n"
 #define MSG_COMP_NOT_FOUND      MSG_PREFIX "0054W" " component %s not found\n"
-#define MSG_STDIN_ERROR         MSG_PREFIX "0055E" " failed to create file for stdin(%s) - %s\n"
+#define MSG_STDIN_CREATE_ERROR  MSG_PREFIX "0055E" " failed to create file for stdin(%s) - %s\n"
+#define MSG_STDIN_OPEN_ERROR    MSG_PREFIX "0056E" " failed to open file for stdin(%s) - %s\n"
 
 #endif // MSG_H
 

--- a/src/msg.h
+++ b/src/msg.h
@@ -68,6 +68,7 @@
 #define MSG_NOT_ALL_STARTED     MSG_PREFIX "0052W" " not all components started\n"
 #define MSG_NOT_ALL_STOPPED     MSG_PREFIX "0053W" " not all components stopped\n"
 #define MSG_COMP_NOT_FOUND      MSG_PREFIX "0054W" " component %s not found\n"
+#define MSG_STDIN_ERROR         MSG_PREFIX "0055E" " failed to create file for stdin(%s) - %s\n"
 
 #endif // MSG_H
 


### PR DESCRIPTION
When Launcher was running as STC, HEREDOCUMENT in shell scripts executed by `popen` didn't work because `stdin` wasn't properly initialized. This PR initializes `stdin` at startup.