### PR TITLE
Update stop component/s in src/main

### DIFF
--- a/src/msg.h
+++ b/src/msg.h
@@ -66,7 +66,7 @@
 #define MSG_COMP_OUTPUT_ERR     MSG_PREFIX "0050E" " cannot read output from comp %s(%d) - %s\n"
 #define MSG_USE_DEFAULTS        MSG_PREFIX "0051W" " failed to read zowe.yaml, launcher will use default settings\n"
 #define MSG_NOT_ALL_STARTED     MSG_PREFIX "0052W" " not all components started\n"
-#define MSG_NOT_ALL_STOPPED     MSG_PREFIX "0053W" " not all components stopped\n"
+#define MSG_NOT_ALL_STOPPED     MSG_PREFIX "0053W" " not all components stopped gracefully\n"
 #define MSG_COMP_NOT_FOUND      MSG_PREFIX "0054W" " component %s not found\n"
 #define MSG_STDIN_CREATE_ERROR  MSG_PREFIX "0055E" " failed to create file for stdin(%s) - %s\n"
 #define MSG_STDIN_OPEN_ERROR    MSG_PREFIX "0056E" " failed to open file for stdin(%s) - %s\n"
@@ -76,6 +76,7 @@
 #define MSG_WKSP_DIR_EMPTY      MSG_PREFIX "0060E" " WORKSPACE_DIR is empty string\n"
 #define MSG_FILE_ERR            MSG_PREFIX "0061E" " failed to find %s='%s', check if the file exists\n"
 #define MSG_MKDIR_ERR           MSG_PREFIX "0062E" " failed to create dir '%s' - %s\n"
+#define MSG_NOT_SIGTERM_STOPPED MSG_PREFIX "0063W" " Component %s(%d) will be terminated using SIGKILL\n"        
 
 #endif // MSG_H
 


### PR DESCRIPTION
This is a customer issue when they try to stop Zowe, some components encountered issue during termination and it goes on loop. The change is to set a timeout during SIGTERM termination and if it reached the timeout it will send SIGKILL.