### PR TITLE
Changing DEBUG messages about script failure to ERROR and WARN

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1086,7 +1086,7 @@ static int run_command(const char *command, handle_line_callback_t handle_line, 
   DEBUG("about to run command '%s'\n", command);
   FILE *fp = popen(command, "r");
   if (!fp) {
-    DEBUG("failed to run command %s - %s\n", command, strerror(errno));
+    ERROR(MSG_CMD_RUN_ERR, command, strerror(errno));
     return -1;
   }
   char *line;
@@ -1097,14 +1097,14 @@ static int run_command(const char *command, handle_line_callback_t handle_line, 
   }
   if (ferror(fp)) {
     pclose(fp);
-    DEBUG("error reading output from command '%s' - %s\n", command, strerror(errno));
+    ERROR(MSG_CMD_OUT_ERR, command, strerror(errno));
     return -1;
   }
   int rc = pclose(fp);
   if (rc == -1) {
-    DEBUG("failed to run command '%s' - %s\n", command, strerror(errno));
+    ERROR(MSG_CMD_RUN_ERR, command, strerror(errno));
   } else if (rc > 0) {
-    DEBUG("command '%s' ended with code %d\n", command, rc);
+    WARN(MSG_CMD_RCP_WARN, command, rc);
     return -1;
   }
   DEBUG("command '%s' ran successfully\n", command);

--- a/src/msg.h
+++ b/src/msg.h
@@ -77,6 +77,9 @@
 #define MSG_FILE_ERR            MSG_PREFIX "0061E" " failed to find %s='%s', check if the file exists\n"
 #define MSG_MKDIR_ERR           MSG_PREFIX "0062E" " failed to create dir '%s' - %s\n"
 #define MSG_NOT_SIGTERM_STOPPED MSG_PREFIX "0063W" " Component %s(%d) will be terminated using SIGKILL\n"        
+#define MSG_CMD_RUN_ERR         MSG_PREFIX "0064E" " failed to run command %s - %s\n"
+#define MSG_CMD_OUT_ERR         MSG_PREFIX "0065E" " error reading output from command '%s' - %s\n"
+#define MSG_CMD_RCP_WARN        MSG_PREFIX "0066W" " command '%s' ended with code %d\n"
 
 #endif // MSG_H
 


### PR DESCRIPTION
A user encountered an issue where "zwe" could not run, but it was not obvious that was the issue, because the messages about command execution were behind DEBUG level. This PR changes some DEBUGs to ERRORs when command rc != 0