### PR TITLE
Disable debug mode by default

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -158,7 +158,7 @@ struct {
   pid_t pid;
   char userid[9];
   
-} zl_context = {.config = {.debug_mode = true}, .userid = "(NONE)"} ;
+} zl_context = {.config = {.debug_mode = false}, .userid = "(NONE)"} ;
 
 
 


### PR DESCRIPTION
Previously debug mode was enabled by default, and when adding configmgr code it caused the log to be quite verbose.
debug mode can be enabled with env var ZLDEBUG, so this can still be enabled by a user in their JCL, but disabling will cause the log to be cleaner.