### PR TITLE
Fix workspace permissions

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1112,8 +1112,7 @@ static int process_workspace_dir(ConfigManager *configmgr) {
   }
 
   // create folder if it doesn't exist
-  // FIXME: what's the proper permission?
-  if (mkdir_all(zl_context.workspace_dir, 0750) != 0) {
+  if (mkdir_all(zl_context.workspace_dir, 0770) != 0) {
     ERROR(MSG_WORKSPACE_ERROR, zl_context.workspace_dir);
     return -1;
   }


### PR DESCRIPTION
2.4 had a regression on that the workspace in older versions was 770 due to one part of code setting 750 and the other overriding it. however in 2.4, the launcher wins and so this old code about 750 ended up with workspace not having enough permissions for admins.