### PR TITLE
Share environment variables from launcher to zwe scripts

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -289,8 +289,7 @@ static void set_shared_uss_env(ConfigManager *configmgr) {
   arrayListAdd(list, "_BPX_SHAREAS");
 
   if (object) { // environments block is defined in zowe.yaml
-    JsonProperty *property;
-    for (property = jsonObjectGetFirstProperty(object); property != NULL; property = jsonObjectGetNextProperty(property)) {
+    for (JsonProperty *property = jsonObjectGetFirstProperty(object); property != NULL; property = jsonObjectGetNextProperty(property)) {
       maxRecords++;
     }
   }
@@ -300,7 +299,7 @@ static void set_shared_uss_env(ConfigManager *configmgr) {
 
   if (object) {
     // Get all environment variables defined in zowe.yaml and put them in the output as they are
-    for (property = jsonObjectGetFirstProperty(object); property != NULL; property = jsonObjectGetNextProperty(property)) {
+    for (JsonProperty *property = jsonObjectGetFirstProperty(object); property != NULL; property = jsonObjectGetNextProperty(property)) {
       char *key = jsonPropertyGetKey(property);
 
       if (!arrayListContains(list, key)) {

--- a/src/main.c
+++ b/src/main.c
@@ -13,7 +13,6 @@
 #include <limits.h>
 #include <stdbool.h>
 #include <stddef.h>
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -290,19 +289,21 @@ static void set_shared_uss_env(ConfigManager *configmgr) {
   arrayListAdd(list, "_BPX_SHAREAS");
 
   if (object) { // environments block is defined in zowe.yaml
-	  JsonProperty *property;
-	  for (property = jsonObjectGetFirstProperty(object); property != NULL; property = jsonObjectGetNextProperty(property)) {
-		  maxRecords++;
-	  }
+    JsonProperty *property;
+    for (property = jsonObjectGetFirstProperty(object); property != NULL; property = jsonObjectGetNextProperty(property)) {
+      maxRecords++;
+    }
+  }
 
-    shared_uss_env = malloc(maxRecords * sizeof(char*));
-    memset(shared_uss_env, 0, maxRecords * sizeof(char*));
+  shared_uss_env = malloc(maxRecords * sizeof(char*));
+  memset(shared_uss_env, 0, maxRecords * sizeof(char*));
 
+  if (object) {
     // Get all environment variables defined in zowe.yaml and put them in the output as they are
     for (property = jsonObjectGetFirstProperty(object); property != NULL; property = jsonObjectGetNextProperty(property)) {
       char *key = jsonPropertyGetKey(property);
 
-		  if (!arrayListContains(list, key)) {
+      if (!arrayListContains(list, key)) {
         arrayListAdd(list, key);
 
         Json *valueJ = jsonPropertyGetValue(property);
@@ -316,10 +317,7 @@ static void set_shared_uss_env(ConfigManager *configmgr) {
         sprintf(entry, "%s=%s", key, value);
         shared_uss_env[idx++] = entry;
       }
-	  }
-  } else {
-    shared_uss_env = malloc(maxRecords * sizeof(char*));
-    memset(shared_uss_env, 0, maxRecords * sizeof(char*));
+    }
   }
 
   // Get all environment variables defined in the system and put them in output if they were not already defined in zowe.yaml
@@ -559,7 +557,7 @@ static int init_components(char *components, ConfigManager *configmgr) {
       break;
     }
     name = strtok(NULL, ",");
-	}
+  }
   return 0;
 }
 
@@ -1267,14 +1265,14 @@ static char* get_sharedenv(void) {
   char *output = NULL;
 
   int required = 0;
-  for (char **env = shared_uss_env + 1; *env != 0; env++) {
+  for (char **env = shared_uss_env + 1; *env != 0; env++) { // First element is NULL, reserved to _BPX_SHAREAS
     char *thisEnv = *env;
     required += (strlen(thisEnv) + 1);
   }
 
   required++;
   output = malloc(required);
-  for (char **env = shared_uss_env + 1; *env != 0; env++) {
+  for (char **env = shared_uss_env + 1; *env != 0; env++) { // First element is NULL, reserved to _BPX_SHAREAS
     char *thisEnv = *env;
     strcat(output, thisEnv);
     trimRight(output, strlen(output));
@@ -1393,7 +1391,6 @@ int main(int argc, char **argv) {
   CFGConfig *theConfig = addConfig(configmgr,ZOWE_CONFIG_NAME);
   cfgSetTraceStream(configmgr,stderr);
   cfgSetTraceLevel(configmgr, zl_context.config.debug_mode ? 2 : 0);
-
   if (init_context(argc, argv, &config, configmgr)) {
     ERROR(MSG_CTX_INIT_FAILED);
     exit(EXIT_FAILURE);

--- a/src/main.c
+++ b/src/main.c
@@ -1478,7 +1478,7 @@ int main(int argc, char **argv) {
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-
+  
   SPDX-License-Identifier: EPL-2.0
 
   Copyright Contributors to the Zowe Project.

--- a/src/main.c
+++ b/src/main.c
@@ -1298,23 +1298,40 @@ static void print_line(void *data, const char *line) {
 
 static char* get_sharedenv(void) {
   char *output = NULL;
+  char *aux = NULL;
 
   int required = 0;
   for (char **env = shared_uss_env + 1; *env != 0; env++) { // First element is NULL, reserved to _BPX_SHAREAS
     char *thisEnv = *env;
-    required += (strlen(thisEnv) + 1);
+    required += (strlen(thisEnv) + 3); // space + quotes
   }
 
   required++;
   output = malloc(required);
+  aux = malloc(required);
   for (char **env = shared_uss_env + 1; *env != 0; env++) { // First element is NULL, reserved to _BPX_SHAREAS
     char *thisEnv = *env;
-    strcat(output, thisEnv);
-    trimRight(output, strlen(output));
-    strcat(output, " ");
+    strcat(aux, thisEnv);
+    char *envName = strtok(aux, "=");
+    if (envName) {
+      strcat(output, envName);
+      char *envValue = &thisEnv[strlen(envName) + 1];
+      if (*envValue == '"') { // Env value is already enclosed in quotes
+        strcat(output, "=");
+        strcat(output, envValue);
+        trimRight(output, strlen(output));
+        strcat(output, " ");
+      } else {
+        strcat(output, "=\"");
+        strcat(output, envValue);
+        trimRight(output, strlen(output));
+        strcat(output, "\" ");
+      }
+    }
+    aux[0] = 0;
   }
   trimRight(output, strlen(output));
-
+  free(aux);
   return output;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1264,10 +1264,23 @@ static void print_line(void *data, const char *line) {
 }
 
 static int prepare_instance() {
-  char command[4*PATH_MAX];
+  char command[5*PATH_MAX];
+  char sharedenv[1*PATH_MAX];
+  
+  for (char **env = environ; *env != 0; env++) {
+    char *thisEnv = *env;
+    char *aux = malloc(strlen(thisEnv) + 2);
+    strcpy(aux, thisEnv);
+    trimRight(aux, strlen(aux));
+    strcat(sharedenv, strcat(aux, " "));
+    free(aux);
+  }
+
+  trimRight(sharedenv, strlen(sharedenv));
+
   DEBUG("about to prepare Zowe instance\n");
-  snprintf(command, sizeof(command), "%s/bin/zwe internal start prepare --config \"%s\" --ha-instance %s 2>&1",
-           zl_context.root_dir, zl_context.config_path, zl_context.ha_instance_id);
+  snprintf(command, sizeof(command), "%s %s/bin/zwe internal start prepare --config \"%s\" --ha-instance %s 2>&1",
+           sharedenv, zl_context.root_dir, zl_context.config_path, zl_context.ha_instance_id);
   if (run_command(command, print_line, NULL)) {
     ERROR(MSG_INST_PREP_ERR);
     return -1;

--- a/src/main.c
+++ b/src/main.c
@@ -334,7 +334,7 @@ static void set_shared_uss_env(ConfigManager *configmgr) {
     for (JsonProperty *property = jsonObjectGetFirstProperty(object); property != NULL; property = jsonObjectGetNextProperty(property)) {
       char *key = jsonPropertyGetKey(property);
       if (!is_valid_key(key)) {
-        WARN("Key `zowe.environments.%s` is invalid and it will be ignored", key);
+        WARN("Key in zowe.yaml `zowe.environments.%s` is invalid and it will be ignored\n", key);
         continue;
       }
 

--- a/src/main.c
+++ b/src/main.c
@@ -255,7 +255,8 @@ static char* escape_string(char *input) {
 
     char *output = malloc(length + quotes + 2 + 1); // add quote on first and the last position and escape quotes inside
     output[0] = '\"';
-    for (int i = 0, j = 1; i < length; i++) {
+    int j = 1;
+    for (int i = 0; i < length; i++) {
         if (input[i] == '\"') {
             output[j++] = '\\';
         }


### PR DESCRIPTION
Environment variables from zowe.yaml take precedence over the ones coming from the system or STC.
This PR merges the environment variables defined in both zowe.yaml and in the system and forwards them to start-prepare and start-component `zwe` commands executions.
