### PR TITLE
Fix debug for configmgr

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1435,6 +1435,7 @@ int main(int argc, char **argv) {
   INFO(MSG_LAUNCHER_START);
 
   zl_config_t config = read_config(argc, argv);
+  zl_context.config = config;
 
   LoggingContext *logContext = makeLoggingContext();
   logConfigureStandardDestinations(logContext);


### PR DESCRIPTION
Debug wasnt working for configmgr because it was reading the context struct but the context struct was not being updated with the debug config struct.
Connected the config struct to the context struct to get debug working for configmgr

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>