### PR TITLE
Force HEAPPOOL off

### DIFF
--- a/samplib/ZWESLSTC
+++ b/samplib/ZWESLSTC
@@ -43,5 +43,6 @@
 //********************************************************************/
 //STDENV   DD  *
 _CEE_ENVFILE_CONTINUATION=\
+_CEE_RUNOPTS="HEAPPOOLS(OFF)"
 CONFIG=#zowe_yaml
 /*


### PR DESCRIPTION
"HEAPPOOLS(OFF)" is needed when using zowe-common-c code that involves the zowe logging context.
the logging context uses a space in memory to hang a pointer that as far as we know is not stated to be used by zOS. yet,  HEAPPOOLS(ON) will occupy the same memory address for some memory manager, causing a conflict which ends in a crash. I haven't seen documentation that HEAPPOOLS does that, but we've observed this multiple times.