### PR TITLE
Fix HEAPPOOLS quotes

### DIFF
--- a/samplib/ZWESLSTC
+++ b/samplib/ZWESLSTC
@@ -43,6 +43,6 @@
 //********************************************************************/
 //STDENV   DD  *
 _CEE_ENVFILE_CONTINUATION=\
-_CEE_RUNOPTS="HEAPPOOLS(OFF)"
+_CEE_RUNOPTS=HEAPPOOLS(OFF)
 CONFIG=#zowe_yaml
 /*


### PR DESCRIPTION
Quotes should not be used in the STDENV section.
Launcher wraps all entries in quotes already, so adding more breaks things.