### PR TITLE
Check if log context was created

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1473,6 +1473,10 @@ int main(int argc, char **argv) {
   zl_context.config = config;
 
   LoggingContext *logContext = makeLoggingContext();
+  if (!logContext) {
+    ERROR(MSG_NO_LOG_CONTEXT);
+    exit(EXIT_FAILURE);
+  }
   logConfigureStandardDestinations(logContext);
 
   ConfigManager *configmgr = makeConfigManager(); /* configs,schemas,1,stderr); */

--- a/src/msg.h
+++ b/src/msg.h
@@ -87,6 +87,7 @@
 #define MSG_CFG_INTERNAL_FAIL   MSG_PREFIX "0071E" " Internal failure during validation, please contact support\n"
 #define MSG_CFG_LOAD_FAIL       MSG_PREFIX "0072E" " Launcher Could not load configurations\n"
 #define MSG_CFG_SCHEMA_FAIL     MSG_PREFIX "0073E" " Launcher Could not load schemas, status=%d\n"
+#define MSG_NO_LOG_CONTEXT      MSG_PREFIX "0074E" " Log context was not created\n"
 
 #endif // MSG_H
 


### PR DESCRIPTION
The logContext requires the allocation of memory. If it is not done for any reason it continues will NULL and it could crash the application then (ie. https://github.com/zowe/community/issues/1852). This PR should prevent this situation.