### PR TITLE
Fixes for environment variables sent to components

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1535,6 +1535,10 @@ int main(int argc, char **argv) {
   zl_context.config = config;
 
   LoggingContext *logContext = makeLoggingContext();
+  if (!logContext) {
+    ERROR(MSG_NO_LOG_CONTEXT);
+    exit(EXIT_FAILURE);
+  }
   logConfigureStandardDestinations(logContext);
 
   ConfigManager *configmgr = makeConfigManager(); /* configs,schemas,1,stderr); */

--- a/src/main.c
+++ b/src/main.c
@@ -54,6 +54,8 @@ extern char ** environ;
 
 #define COMP_ID "ZWELNCH"
 
+#define CEE_ENVFILE_PREFIX        "_CEE_ENVFILE"
+
 #define MIN_UPTIME_SECS 90
 
 #define SHUTDOWN_GRACEFUL_PERIOD (20 * 1000)
@@ -372,6 +374,11 @@ static void set_shared_uss_env(ConfigManager *configmgr) {
         continue;
       }
 
+      if (strncmp(key, CEE_ENVFILE_PREFIX, strlen(CEE_ENVFILE_PREFIX)) == 0) {
+        DEBUG("Ignoring environment variable: %s, conflict\n", key);
+        continue;
+      }
+
       if (!arrayListContains(list, key)) {
         arrayListAdd(list, key);
 
@@ -384,18 +391,6 @@ static void set_shared_uss_env(ConfigManager *configmgr) {
 
         char *entry = malloc(strlen(key) + strlen(value) + 2);
 
-        // REMOVE?
-        if (value[0] == '"') {
-          value[strlen(value) - 1] = 0;
-          value = value + 1;
-        }
-        // REMOVE?
-
-        // REMOVE?
-        trimRight(value, strlen(value));
-        printf("setting \"%s\" (%lu) with value \"%s\" (%lu)\n", key, strlen(key), value, strlen(value));
-        // REMOVE?
-
         sprintf(entry, "%s=%s", key, value);
         shared_uss_env[idx++] = entry;
       }
@@ -407,6 +402,10 @@ static void set_shared_uss_env(ConfigManager *configmgr) {
     char *thisEnv = *env;
     char *index = strchr(thisEnv, '=');
     if (!index) {
+      continue;
+    }
+    if (strncmp(thisEnv, CEE_ENVFILE_PREFIX, strlen(CEE_ENVFILE_PREFIX)) == 0) {
+      DEBUG("Ignoring environment variable: %s, conflict\n", thisEnv);
       continue;
     }
 
@@ -778,14 +777,49 @@ static int start_component(zl_comp_t *comp) {
 
   shared_uss_env[0] = (char *)get_shareas_env(comp);
 
-  // REMOVE
-  for (char **env = shared_uss_env; *env != 0; env++) {
-    char *thisEnv = *env;
-    printf("Entry in shared_uss_env is '%s' with length %lu\n", thisEnv, strlen(thisEnv));
-  }
-  // REMOVE
+  int env_count = 8;
+  
+  const char *c_env[10];
 
-  comp->pid = spawn(bin, fd_count, fd_map, &inherit, c_args, (const char **)shared_uss_env);
+  int i = 0;
+  char *aux = NULL;
+  char *output = NULL;
+  for (char **env = shared_uss_env; *env != 0 && i < env_count; env++) {
+    char *thisEnv = *env;
+    aux = malloc(strlen(thisEnv) + 1);
+    output = malloc(strlen(thisEnv) + 1);
+    strncpy(aux, thisEnv, strlen(thisEnv));
+    //printf("aux: %s\n", aux);
+    char *envName = strtok(aux, "=");
+    //printf("envName: %s\n", envName);
+    if (envName) {
+      if (strncmp(envName, "_CEE", 4) == 0) {
+        continue;
+      }
+      strcat(output, envName);
+      char *envValue = &aux[strlen(envName) + 1];
+      
+      setenv(envName, envValue, 0);
+
+      strcat(output, "=");
+      strcat(output, envValue);
+      output[strlen(thisEnv)] = 0;
+      trimRight(output, strlen(output));
+      printf("element %d is '%s'\n", i, output);
+    }
+    aux[0] = 0;
+    c_env[i] = output;
+    i++;
+  }
+  c_env[i] = NULL;
+  
+  for (int j = 0; j < i; j++) {
+    const char *str = c_env[j];
+    int str_length = strlen(str);
+    printf("last characters of '%s': 0x%08X, 0x%08X, 0x%08X, 0x%08X\n", str, str[str_length - 3], str[str_length - 2], str[str_length - 1], str[str_length]);
+  }
+
+  comp->pid = spawn(bin, fd_count, fd_map, &inherit, c_args, c_env);
   if (comp->pid == -1) {
     DEBUG("spawn() failed for %s - %s\n", comp->name, strerror(errno));
     return -1;

--- a/src/main.c
+++ b/src/main.c
@@ -735,12 +735,10 @@ static const char **env_comp(zl_comp_t *comp) {
   const char **env_comp = malloc(env_records + 1);
 
   int i = 0;
-  char *aux = NULL;
   for (char **env = shared_uss_env; *env != 0 && i < env_records; env++) {
     char *thisEnv = *env;
-    aux = malloc(strlen(thisEnv) + 1);
+    char *aux = malloc(strlen(thisEnv) + 1);
     strncpy(aux, thisEnv, strlen(thisEnv));
-    aux[strlen(thisEnv)] = 0;
     trimRight(aux, strlen(aux));
     env_comp[i] = aux;
     i++;
@@ -1272,7 +1270,7 @@ static void handle_get_component_line(void *data, const char *line) {
   }
 }
 
-static char* get_get_launch_components_cmd(char* sharedenv) {
+static char* get_launch_components_cmd(char* sharedenv) {
   const char basecmd[] = "%s %s/bin/zwe internal get-launch-components --config \"%s\" --ha-instance %s";
   int size = strlen(zl_context.root_dir) + strlen(zl_context.config_path) + strlen(zl_context.ha_instance_id) + strlen(sharedenv) + sizeof(basecmd) + 1;
   char *command = malloc(size);
@@ -1329,7 +1327,7 @@ static char* get_sharedenv(void) {
 
 static int get_component_list(char *buf, size_t buf_size) {
   char *sharedenv = get_sharedenv();
-  char *command = get_get_launch_components_cmd(sharedenv);
+  char *command = get_launch_components_cmd(sharedenv);
 
   free(sharedenv);
 

--- a/src/msg.h
+++ b/src/msg.h
@@ -87,6 +87,7 @@
 #define MSG_CFG_INTERNAL_FAIL   MSG_PREFIX "0071E" " Internal failure during validation, please contact support\n"
 #define MSG_CFG_LOAD_FAIL       MSG_PREFIX "0072E" " Launcher Could not load configurations\n"
 #define MSG_CFG_SCHEMA_FAIL     MSG_PREFIX "0073E" " Launcher Could not load schemas, status=%d\n"
+#define MSG_NO_LOG_CONTEXT      MSG_PREFIX "0074E" " Log context was not created\n"
 
 #endif // MSG_H
 


### PR DESCRIPTION
- `_CEE_ENVFILE*` are not sent downwards to the components to avoid conflicts.
- Send a memory copy of environment variable list.
- Fix to send environment variables for `zwe internal get-launch-components`

Resolve #75 