### PR TITLE
 Update pointer to allow bypass version check pr

### DIFF
--- a/build/launcher.proj.env
+++ b/build/launcher.proj.env
@@ -12,4 +12,4 @@ LIBYAML_BRANCH="0.2.5"
 
 COMMON="common"
 COMMON_SOURCE="git@github.com:zowe/zowe-common-c.git"
-COMMON_BRANCH="v2.x/staging"
+COMMON_BRANCH="feature/v2/allow-bypass-version-check"


### PR DESCRIPTION
This PR just updates the pointer of zowe-common-c to https://github.com/zowe/zowe-common-c/pull/390