### PR TITLE
Fix syslog output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the Zowe Launcher package will be documented in this file..
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 2.13.0
+
+- Bugfix: Changed timestamp to UTC to match the server timestamps (#103)
+- Bugfix: Removed server timestamps from syslog to avoid duplicate logging of time (#103)
+- Bugfix: Avoided hang on components when components were logging messages longer than 1024 characters. (#103)
+- Enhancement: syslog output per line is capped at 512 bytes, extra characters will be omitted (#103)
+- Enhancement: Added milliseconds logging to match the server timestamps (#103)
+
 ## 2.12.0
 - Added a wrapper for wtoPrintf3
 - Bugfix: Fixed a gap in WTO syslog checking

--- a/src/main.c
+++ b/src/main.c
@@ -223,7 +223,7 @@ static int index_of_string_limited(char *str, int len, char *search_string, int 
   int last_possible_start = len-search_limit;
   int pos = start_pos;
 
-  if (startPos > last_possible_start){
+  if (start_pos > last_possible_start){
     return -1;
   }
   while (pos <= last_possible_start){
@@ -235,7 +235,7 @@ static int index_of_string_limited(char *str, int len, char *search_string, int 
   return -1;
 }
 
-static void check_for_and_print_sys_message(const char* line) {
+static void check_for_and_print_sys_message(const char* input_string) {
   if (!zl_context.sys_messages) {
     return;
   }
@@ -247,7 +247,7 @@ static void check_for_and_print_sys_message(const char* line) {
     if (sys_message_id && (index_of_string_limited(input_string, input_length, sys_message_id, 0, SYSLOG_MESSAGE_LENGTH_LIMIT) != -1)) {
       //truncate match for reasonable output
       char syslog_string[SYSLOG_MESSAGE_LENGTH_LIMIT+1] = {0};
-      int length = SYSLOG_MESSAGE_LENGTH_LIMIT < input_length ? SYSLOG_MESSAGE_LENGTH_LIMIT : input_lenth;
+      int length = SYSLOG_MESSAGE_LENGTH_LIMIT < input_length ? SYSLOG_MESSAGE_LENGTH_LIMIT : input_length;
       memcpy(syslog_string, input_string, length);
       syslog_string[length] = '\0';
 

--- a/src/main.c
+++ b/src/main.c
@@ -66,7 +66,8 @@ extern char ** environ;
 
 #define COMP_LIST_SIZE 1024
 
-#define SYSLOG_MESSAGE_LENGTH_LIMIT 512
+#define LAUNCHER_MESSAGE_LENGTH_LIMIT 512
+#define SYSLOG_MESSAGE_LENGTH_LIMIT 126
 
 #ifndef PATH_MAX
 #define PATH_MAX _POSIX_PATH_MAX
@@ -208,7 +209,7 @@ static void launcher_syslog_on_match(const char* fmt, ...) {
   
   /* All of this stuff here is because I can't do 
   #define INFO(fmt, ...)  check_for_and_print_sys_message(fmt, ...) so let's make a string */
-  char input_string[SYSLOG_MESSAGE_LENGTH_LIMIT+1];
+  char input_string[LAUNCHER_MESSAGE_LENGTH_LIMIT+1];
   va_list args;
   va_start(args, fmt);
   vsnprintf(input_string, sizeof(input_string), fmt, args);


### PR DESCRIPTION
This PR solves the following:
1) launcher timestamps were not matching server time (local versus UTC)
2) launcher timestamps were not matching server style (missing milliseconds)
3) syslog printing was including timestamps, despite syslog already having timestamps. now, via regex launcher detects and omits timestamps. it makes lines easier to read.
4) Attempt to fix a bug where a server trying to print a line longer than 1024 would hang due to the syslog routing logic only having a 1024 buffer. now, there is no limit but the output will be truncated to 512 chars to make the syslog easier to read.