### PR TITLE
Set HEAPPOOLS64 to OFF

### DIFF
--- a/samplib/ZWESLSTC
+++ b/samplib/ZWESLSTC
@@ -55,7 +55,7 @@
 //********************************************************************/
 //STDENV   DD  *
 _CEE_ENVFILE_CONTINUATION=\
-_CEE_RUNOPTS=HEAPPOOLS(OFF)
+_CEE_RUNOPTS=HEAPPOOLS(OFF),HEAPPOOLS64(OFF)
 _EDC_UMASK_DFLT=0002
 CONFIG=#zowe_yaml
 /*


### PR DESCRIPTION
As seen in https://github.com/zowe/zowe-install-packaging/pull/3799 
HEAPOOLS64(OFF) should be the default for anything derived from le.c / logging.c from zowe-common-c, which includes the launcher.