### PR TITLE
Appending the copied env string with NULL character before trimming.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -896,6 +896,7 @@ static const char **env_comp(zl_comp_t *comp) {
     char *thisEnv = *env;
     char *aux = malloc(strlen(thisEnv) + 1);
     strncpy(aux, thisEnv, strlen(thisEnv));
+    aux[strlen(thisEnv)] = '\0';
     trimRight(aux, strlen(aux));
     env_comp[i] = aux;
     i++;


### PR DESCRIPTION
In module '**env_comp**()', when copying the environment variable string, the trimRight() function is being called immediately after copying the bytes equivalent to the length of the string. 

The trimRight() function removes the spaces if any and then appends the NULL character, but this doesn't happen with strings that have no spaces in them, hence we add the NULL character before we send the string to be trimmed. 

Related to PR: https://github.com/zowe/launcher/pull/115/