### PR TITLE
Fix component enabled check not considering HA instance

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -5,7 +5,7 @@ name: launcher
 # Component identifier. This identifier matches artifact path in Zowe Artifactory https://zowe.jfrog.io/.
 id: org.zowe.launcher
 # Component version
-version: 2.18.0
+version: 2.17.0
 # Human readable component name
 title: Zowe Launcher
 # Human readable component description

--- a/src/main.c
+++ b/src/main.c
@@ -1578,15 +1578,21 @@ static int get_component_list(char *buf, size_t buf_size,ConfigManager *configmg
   bool checkHaSection = false;
 
   Json *haInstancesJson = NULL;
-  getStatus = cfgGetAny(configmgr, ZOWE_CONFIG_NAME, &haInstancesJson, 1, "haInstances");
+  int getStatus = cfgGetAnyC(configmgr, ZOWE_CONFIG_NAME, &haInstancesJson, 1, "haInstances");
   if (!getStatus) {
     if ((!strcmp(zl_context.ha_instance_id, "__ha_instance_id__")) || (!strcmp(zl_context.ha_instance_id, "{{ha_instance_id}}"))) {
       int rc = 0;
       int rsn = 0;
       char *resolvedName = resolveSymbol("&SYSNAME", &rc, &rsn);
       if (!rc) {
+        //ha instance name is always lowercase if derived from sysname automatically.
+        int nameLength = strlen(resolvedName);
+        for(int i = 0; i < nameLength; i++){
+          resolvedName[i] = tolower(resolvedName[i]);
+        }
+
         // Resolves ha instance id for downstream as well.
-        zl_context.ha_instance_id = resolvedName;
+        snprintf(zl_context.ha_instance_id, 8+1, "%s", resolvedName);
         checkHaSection = true;
       } else {
         ERROR("Could not resolve SYSNAME for HA instance lookup, rc=0x%x, rsn=0x%x\n", rc, rsn);
@@ -1601,7 +1607,7 @@ static int get_component_list(char *buf, size_t buf_size,ConfigManager *configmg
   if (jsonIsObject(result)) {
     JsonObject *resultObj = jsonAsObject(result);
     JsonProperty *prop = resultObj->firstProperty;
-    int getStatus = cfgGetStringC(configmgr, ZOWE_CONFIG_NAME, &runtimeDirectory, 2, "zowe", "runtimeDirectory");
+    getStatus = cfgGetStringC(configmgr, ZOWE_CONFIG_NAME, &runtimeDirectory, 2, "zowe", "runtimeDirectory");
     if (getStatus) {
       getStatus = cfgGetStringC(configmgr, ZOWE_CONFIG_NAME, &extensionDirectory, 2, "zowe", "extensionDirectory");
       if (getStatus) {
@@ -1616,7 +1622,7 @@ static int get_component_list(char *buf, size_t buf_size,ConfigManager *configmg
       enabled = false;
       // check if component is enabled
       if (checkHaSection) {
-        getStatus = cfgGetBooleanC(configmgr, ZOWE_CONFIG_NAME, &enabled, 4, "haInstances", haInstName, "components", prop->key, "enabled");
+        getStatus = cfgGetBooleanC(configmgr, ZOWE_CONFIG_NAME, &enabled, 5, "haInstances", zl_context.ha_instance_id, "components", prop->key, "enabled");
         if (getStatus) {
           getStatus = cfgGetBooleanC(configmgr, ZOWE_CONFIG_NAME, &enabled,3, "components", prop->key, "enabled");
         }


### PR DESCRIPTION
Upon testing, I found that recent changes in #117 did not take HA instance into account.

I had a config like this:

```yaml
components:
  zss:
    enabled: true

haInstances:
  mySys:
    components:
      zss:
        enabled: false
```

And witnessed the launcher would still try to start zss.

To accomodate haInstances, you must either use the user-supplied instance name, or derive it from the system name.

In this PR, I have used zowe-common-c "resolveSymbol" to get &SYSNAME when the user did not supply an ha Instance name.

The rules of zowe-install-packaging code that #117 replaces also says the sysname should be lower-case.

I tested this by varying the booleans above between true/false, and entirely omitting the haInstances object, to see what would happen.

Testing reveals a fix in the regression.