### PR TITLE
Fix for checking wrong directory for extensions

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1605,8 +1605,8 @@ static int get_component_list(char *buf, size_t buf_size,ConfigManager *configmg
       yamlExists = true;
       if (check_if_yaml_exists(manifestPath, "MANIFEST.YAML")) {
         yamlExists = false;
-        // if not check instance/extensions/component/manifest.yaml
-        snprintf(manifestPath, PATH_MAX, "%s/components/%s/manifest.yaml", extensionDirectory, prop->key);
+        // if not check <extensionDirectory>/<componentname>/manifest.yaml
+        snprintf(manifestPath, PATH_MAX, "%s/%s/manifest.yaml", extensionDirectory, prop->key);
         DEBUG("manifest path for component %s is %s\n", prop->key, manifestPath);
         if(!check_if_yaml_exists(manifestPath, "MANIFEST.YAML"))
            yamlExists = true;

--- a/src/main.c
+++ b/src/main.c
@@ -1584,11 +1584,11 @@ static int get_component_list(char *buf, size_t buf_size,ConfigManager *configmg
     if (!getStatus) {
       getStatus = cfgGetStringC(configmgr, ZOWE_CONFIG_NAME, &extensionDirectory, 2, "zowe", "extensionDirectory");
       if (getStatus) {
-        ERROR(" failed to get extensionDirectory");
+        ERROR("failed to get extensionDirectory\n");
         return -1;
       }
     } else {
-      ERROR(" failed to get runtimeDirectory");
+      ERROR("failed to get runtimeDirectory\n");
       return -1;
     }
 


### PR DESCRIPTION
The startup code which determines which extensions should run was checking the wrong directory, not finding the manifest, and then not running them.

Additionally, I take the yaml lookup code and put it under a conditional to not run if the component is not enabled, as that is not necessary.
