### PR TITLE
TEST for #144

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -128,7 +128,7 @@ jobs:
         run: |
           result=$(node ./buildZwelMessages.js --check)
           if [ "${result}" != "0" ]; then
-            echo "Problem detected, see the previous messages."
+            echo "${result}"
             exit 1
           fi
 

--- a/build/zwelMessages.js
+++ b/build/zwelMessages.js
@@ -15,12 +15,6 @@ const ZOS_MIN_SUPPORTED = '2.5.0'
 
 export const MESSAGES = [
     {
-        id: "ZWEL0001I",
-        text: "component %s started",
-        reason: "The component `<component-name>` was started.",
-        action: NO_ACTION
-    },
-    {
         id: "ZWEL0002I",
         text: "component %s stopped",
         reason: "The component `<component-name>` was stopped.",


### PR DESCRIPTION
Removed one message from `zwelMessages.js`, workflow failed (expected) with missing message:
```
Run result=$(node ./buildZwelMessages.js --check)
1
Missing ZWEL message(s) in documentation:
[ 'ZWEL0001I' ]
```