### PR TITLE
Allow different member names for PARMLIB entries of CONFIG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zowe Launcher package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 3.3
+- Enhancement: Launcher can now accept PARMLIB CONFIG entries that have more than one member name ([#146](https://github.com/zowe/launcher/pull/146))
+
 ## 3.1
 - Bugfix: HEAPPOOLS and HEAPPOOLS64 no longer need to be set to OFF for launcher (#133)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: EPL-2.0
 
 Copyright Contributors to the Zowe Project.
 
-<h1 align="center">Zowe Launcher</h1>
+# Zowe Launcher
 
 The Zowe launcher is a part of the Zowe server architecture that was added as an optional program for HA/FT usage in v1.
 In v2, the Zowe laucher became the sole way to start the Zowe servers.
@@ -31,6 +31,10 @@ cd zowe-launcher/build
 ```
 
 The launcher binary will be saved into the bin directory.
+
+## Testing
+
+See [details](./test/README.md) in `test` directory.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: EPL-2.0
 
 Copyright Contributors to the Zowe Project.
 
-# Zowe Launcher
+<h1 align="center">Zowe Launcher</h1>
 
 The Zowe launcher is a part of the Zowe server architecture that was added as an optional program for HA/FT usage in v1.
 In v2, the Zowe laucher became the sole way to start the Zowe servers.

--- a/samplib/ZWESLSTC
+++ b/samplib/ZWESLSTC
@@ -51,8 +51,6 @@
 //* from files to their right.
 //* Typically the right-most file should be the Zowe default yaml.
 //*
-//* Note: All PARMLIB() entries must all have the same member name.
-//*
 //********************************************************************/
 //STDENV   DD  *
 _CEE_ENVFILE_CONTINUATION=\

--- a/src/main.c
+++ b/src/main.c
@@ -575,6 +575,7 @@ static int init_context(int argc, char **argv, const struct zl_config_t *cfg, Co
   if (zl_context.config_path[0] == '/') { // simple file case, must be absolute path.
     snprintf(config_line, config_len+7, "FILE(%s)", zl_context.config_path);
     snprintf(zl_context.configmgr_path, config_len+7, "%s", config_line);
+    setenv("CONFIG", zl_context.config_path, 1);
   } else {
     //check that PARMLIB has no missing members
     int parmIndex = indexOfString(zl_context.config_path, config_len, "PARMLIB(", 0);
@@ -586,10 +587,10 @@ static int init_context(int argc, char **argv, const struct zl_config_t *cfg, Co
       }
       parmIndex = indexOfString(zl_context.config_path, config_len, "PARMLIB(", rParenIndex);
     }
+    snprintf(zl_context.configmgr_path, config_len+1, "%s", zl_context.config_path);
   }
 
 
-  setenv("CONFIG", zl_context.config_path, 1);
   INFO(MSG_YAML_FILE, zl_context.configmgr_path);
 
   zl_context.config = *cfg;

--- a/src/main.c
+++ b/src/main.c
@@ -581,7 +581,10 @@ static int init_context(int argc, char **argv, const struct zl_config_t *cfg, Co
     int parmIndex = indexOfString(zl_context.config_path, config_len, "PARMLIB(", 0);
     while (parmIndex != -1) {
       int rParenIndex = indexOfString(zl_context.config_path, config_len, "))", parmIndex);
-      if (rParenIndex == -1) {
+      //find ( after PARMLIB( section, to find where member name should be
+      int lParenIndex = indexOfString(zl_context.config_path, config_len, "(", parmIndex+9);
+      if ((rParenIndex == -1)
+          || (rParenIndex == (lParenIndex+1))) {
         ERROR(MSG_MEMBER_MISSING);
         return -1;
       }

--- a/src/main.c
+++ b/src/main.c
@@ -172,7 +172,6 @@ struct {
   char config_path[PATH_MAX*17];
   //configmgr_path is the path in a form configmgr consumes
   char configmgr_path[PATH_MAX*17];
-  char parm_member[8+1];
   char *root_dir;
   char *workspace_dir;
   JsonArray *sys_messages;
@@ -572,53 +571,21 @@ static int init_context(int argc, char **argv, const struct zl_config_t *cfg, Co
   }
 
   int config_len = strlen(zl_context.config_path);
-  bool hasMember = false;
-  char member[9] = {0};
   char config_line[PATH_MAX*17] = {0};
   if (zl_context.config_path[0] == '/') { // simple file case, must be absolute path.
     snprintf(config_line, config_len+7, "FILE(%s)", zl_context.config_path);
     snprintf(zl_context.configmgr_path, config_len+7, "%s", config_line);
-  } else { //HERE loop over input to construct new string for configmgr use.
-    // It needs to strip out the (member) within each occurrence of PARMLIB()
+  } else {
+    //check that PARMLIB has no missing members
     int parmIndex = indexOfString(zl_context.config_path, config_len, "PARMLIB(", 0);
-    int destPos = 0;
-    int srcPos = 0;
-    DEBUG("Handling config=%s\n",zl_context.config_path);
     while (parmIndex != -1) {
-      int parenStartIndex = indexOf(zl_context.config_path, config_len, '(', parmIndex+9);
-      int parenEndIndex = indexOf(zl_context.config_path, config_len, ')', parmIndex+9);
-      DEBUG("pStart=%d, pEnd=%d\n", parenStartIndex, parenEndIndex);
-      if (parenStartIndex != -1 && parenEndIndex != -1 && (parenStartIndex < parenEndIndex)) {
-        memcpy(zl_context.parm_member, zl_context.config_path+parenStartIndex+1, parenEndIndex-parenStartIndex-1);
-        if (hasMember && strcmp(zl_context.parm_member, member) != 0) {
-          ERROR(MSG_MEMBER_NAME_BAD);
-          return -1;
-        }
-        hasMember = true;
-        memcpy(member, zl_context.config_path+parenStartIndex+1, parenEndIndex-parenStartIndex-1);
-        DEBUG("Found member=%s\n",member);
-        memcpy(config_line+destPos, zl_context.config_path+srcPos, parenStartIndex-srcPos);
-        destPos+= parenStartIndex-srcPos;
-        srcPos=parenEndIndex+1;
-        parmIndex = indexOfString(zl_context.config_path, config_len, "PARMLIB(", parenEndIndex+2);
-      } else {
+      int rParenIndex = indexOfString(zl_context.config_path, config_len, "))", parmIndex);
+      if (rParenIndex == -1) {
         ERROR(MSG_MEMBER_MISSING);
         return -1;
       }
-      DEBUG("config_line now=%s\n", config_line);
-      DEBUG("src=%d, dst=%d, pNext=%d\n",srcPos,destPos,parmIndex);
+      parmIndex = indexOfString(zl_context.config_path, config_len, "PARMLIB(", rParenIndex);
     }
-
-    if (destPos >= 0) {
-      memcpy(config_line+destPos, zl_context.config_path+srcPos, config_len - srcPos);
-      destPos+= config_len - srcPos;
-      memcpy(zl_context.configmgr_path, config_line, destPos);
-      zl_context.configmgr_path[destPos]='\0';
-    }
-    if (!hasMember) {
-      zl_context.parm_member[0] = '\0';
-    }
-  
   }
 
 
@@ -1899,10 +1866,6 @@ int main(int argc, char **argv) {
   }
 
   cfgSetConfigPath(configmgr, ZOWE_CONFIG_NAME, zl_context.configmgr_path);
-  int parm_member_len = strlen(zl_context.parm_member);
-  if (parm_member_len > 0 && parm_member_len < 9) {
-    cfgSetParmlibMemberName(configmgr, ZOWE_CONFIG_NAME, zl_context.parm_member);
-  }
 
   if (cfgLoadConfiguration(configmgr, ZOWE_CONFIG_NAME) != 0){
     ERROR(MSG_CFG_LOAD_FAIL);

--- a/src/msg.h
+++ b/src/msg.h
@@ -79,7 +79,7 @@
 #define MSG_CMD_RUN_ERR         MSG_PREFIX "0064E" " failed to run command %s - %s\n"
 #define MSG_CMD_OUT_ERR         MSG_PREFIX "0065E" " error reading output from command '%s' - %s\n"
 #define MSG_CMD_RCP_WARN        MSG_PREFIX "0066W" " command '%s' ended with code %d\n"
-#define MSG_MEMBER_NAME_BAD     MSG_PREFIX "0067E" " PARMLIB() entries must all have the same member name\n"
+# 67E retired, parmlib member name restriction removed
 #define MSG_MEMBER_MISSING      MSG_PREFIX "0068E" " PARMLIB() entries must have a member name\n"
 #define MSG_CFG_VALID           MSG_PREFIX "0069I" " Configuration is valid\n"
 #define MSG_CFG_INVALID         MSG_PREFIX "0070E" " Configuration has validity exceptions:\n"
@@ -901,19 +901,6 @@
 //@  **Action:**
 //@
 //@  Review the error text to determine the action to take.
-//@
-// #define MSG_MEMBER_NAME_BAD     MSG_PREFIX "0067E" " PARMLIB() entries must all have the same member name\n"
-//@### ZWEL0067E
-//@
-//@  PARMLIB() entries must all have the same member name
-//@
-//@  **Reason:**
-//@
-//@  PARMLIB() entries must all have the same member name.
-//@
-//@  **Action:**
-//@
-//@  Review the member names are identical for all PARMLIB() entries.
 //@
 // #define MSG_MEMBER_MISSING      MSG_PREFIX "0068E" " PARMLIB() entries must have a member name\n"
 //@### ZWEL0068E

--- a/src/msg.h
+++ b/src/msg.h
@@ -79,7 +79,7 @@
 #define MSG_CMD_RUN_ERR         MSG_PREFIX "0064E" " failed to run command %s - %s\n"
 #define MSG_CMD_OUT_ERR         MSG_PREFIX "0065E" " error reading output from command '%s' - %s\n"
 #define MSG_CMD_RCP_WARN        MSG_PREFIX "0066W" " command '%s' ended with code %d\n"
-# 67E retired, parmlib member name restriction removed
+// 67E retired, parmlib member name restriction removed
 #define MSG_MEMBER_MISSING      MSG_PREFIX "0068E" " PARMLIB() entries must have a member name\n"
 #define MSG_CFG_VALID           MSG_PREFIX "0069I" " Configuration is valid\n"
 #define MSG_CFG_INVALID         MSG_PREFIX "0070E" " Configuration has validity exceptions:\n"

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,16 @@
+<!--
+This program and the accompanying materials are
+made available under the terms of the Eclipse Public License v2.0 which accompanies
+this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+SPDX-License-Identifier: EPL-2.0
+
+Copyright Contributors to the Zowe Project.
+-->
+
+# Tests
+
+## Config-syntax
+
+Simple shell script to test basic functionality, such as treating items in environment variable `CONFIG`, `haInstace` and typical start-up messages.
+Return code is the number detected errors. To see an output, use any parameter, for example `./config-syntax.sh print`.

--- a/test/config-syntax.sh
+++ b/test/config-syntax.sh
@@ -3,9 +3,9 @@
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies
 # this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
-# 
+#
 # Copyright Contributors to the Zowe Project.
 
 # Start with_any_paramter -> prints output (diff style)
@@ -19,6 +19,13 @@ if [ ! -z "${1}" ]; then
 fi
 
 LAUNCHER='../bin/zowe_launcher'
+ABS_PATH=$(cd .; pwd)
+
+TEST_FILES='./files'
+ZOWE="${TEST_FILES}/zowe.runtime.dev.null.yaml"
+ZOWE_EMPTY="${TEST_FILES}/zowe.empty.yaml"
+ABS_ZOWE="${ABS_PATH}/${ZOWE}"
+ABS_ZOWE2="${ABS_PATH}/././././////./////${ZOWE}"
 
 run_launcher() {
     # trim via awk
@@ -52,6 +59,8 @@ run_launcher() {
         if [ -z "${findText}" ]; then
             echo "- >  Not found: ${textMatch}"
             errors=`expr $errors + 1`
+        else
+            [ ! -z "${print}" ] && echo "+ >  Found: ${textMatch}"
         fi
     fi
 
@@ -60,20 +69,24 @@ run_launcher() {
 
 IFS='|'
 while read config haInstace textMatch desc debug; do
+    # Skip the first line
     if [ "${config}" != "CONFIG " ]; then
-        run_launcher $config $haInstace $textMatch $desc $debug 
+        run_launcher $config $haInstace $textMatch $desc $debug
     fi
 done <<EOF
 CONFIG | HA-INSTANCE | TEXT-TO-FIND | DESCRIPTION | ZLDEBUG
- | | PANIC! readJson got null pathElement | No config lead to PANIC!
-/git/repos/launcher/bin/zowe.yaml | | ZWEL0021I Zowe Launcher starting | Check the basic message ZWEL0021I
-/git/repos/launcher/bin/zowe.yaml | | INFO ZWEL0023I Zowe YAML config file is 'FILE(/git/repos/launcher/bin/zowe.yaml)' | ZWEL0023I wrapped by FILE()
-FILE(/git/repos/launcher/bin/zowe.yaml) | | INFO ZWEL0023I Zowe YAML config file is 'FILE(/git/repos/launcher/bin/zowe.yaml)' | Same as previous test
-FILE(/git/repos/launcher/bin/zowe.yaml) | LPAR123 | ZWEL0024I HA_INSTANCE_ID is 'lpar123' | HaInstance should be sanitazed
-PARMLIB(ZOWE.PR4285.A(A)) | hello | ZWEL0023I Zowe YAML config file is 'PARMLIB(ZOWE.PR4285.A(A))' | Parmlib does not exist, but it should be in ZWEL00203I
-PARMLIB(ZOWE.PR4285.A) | hello | ZWEL0068E PARMLIB() entries must have a member name | Should detect missing member
-PARMLIB(ZOWE.PR4285.A() | hello | ZWEL0068E PARMLIB() entries must have a member name | Should detect missing member
-PARMLIB(ZOWE.PR4285.A()) | hello | ZWEL0068E PARMLIB() entries must have a member name | Should detect missing member
+ | | PANIC! readJson got null pathElement | No config leads to PANIC!
+FILE(${ZOWE_EMPTY}) | | ZWEL0318E - failed to get root node in YAML | Empty config leads to ZWEL0318E
+${ABS_ZOWE} | | ZWEL0021I Zowe Launcher starting | Check the basic message ZWEL0021I
+${ZOWE} | | INFO ZWEL0023I Zowe YAML config file is 'FILE(${ZOWE})' | ZWEL0023I wrapped by FILE()
+FILE(${ZOWE}) | | INFO ZWEL0023I Zowe YAML config file is 'FILE(${ZOWE})' | Same as previous test
+${ABS_ZOWE} | | INFO ZWEL0023I Zowe YAML config file is 'FILE(${ABS_ZOWE})' | ZWEL0023I wrapped by FILE()
+${ABS_ZOWE2} | | INFO ZWEL0023I Zowe YAML config file is 'FILE(${ABS_ZOWE2})' | Should be able to read the file
+FILE(${ZOWE}) | LPAR123 | ZWEL0024I HA_INSTANCE_ID is 'lpar123' | HaInstance should be sanitazed
+PARMLIB(ZOWE.TEST-1.A(A)) | hello | ZWEL0023I Zowe YAML config file is 'PARMLIB(ZOWE.TEST-1.A(A))' | Parmlib does not exist, but it should be in ZWEL00203I
+PARMLIB(ZOWE.TEST-1.A) | world | ZWEL0068E PARMLIB() entries must have a member name | Should detect missing member
+PARMLIB(ZOWE.TEST-1.A() | | ZWEL0068E PARMLIB() entries must have a member name | Should detect missing member
+PARMLIB(ZOWE.TEST-1.A()) | | ZWEL0068E PARMLIB() entries must have a member name | Should detect missing member
 EOF
 
 exit $errors

--- a/test/config-syntax.sh
+++ b/test/config-syntax.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Copyright Contributors to the Zowe Project.
+
+# Start with_any_paramter -> prints output (diff style)
+#   rc of this = number of errors found
+
+print=
+errors=0
+
+if [ ! -z "${1}" ]; then
+    print='1'
+fi
+
+LAUNCHER='../bin/zowe_launcher'
+
+run_launcher() {
+    # trim via awk
+    config=$(echo "$1" | awk '{$1=$1};1')
+    haInstance=$(echo "$2" | awk '{$1=$1};1')
+    textMatch=$(echo "$3" | awk '{$1=$1};1')
+    desc=$(echo "$4" | awk '{$1=$1};1')
+    debug=$(echo "$5" | awk '{$1=$1};1')
+
+    export ZLDEBUG=
+    if [ ! -z "${debug}" ]; then
+        export ZLDEBUG='ON'
+    fi
+
+    export CONFIG="${config}"
+    # Filter out the long line when printing
+    if [ -n "${print}" ]; then
+        result=$($LAUNCHER "${haInstance}" 2>&1 | grep -v "INFO -- If you cant see '500'")
+    else
+        result=$($LAUNCHER "${haInstance}" 2>&1)
+    fi
+
+    [ ! -z "${desc}" ] && [ ! -z "${print}" ] && echo "+ >>> ${desc}"
+    [ ! -z "${print}" ] && echo "+ >  CONFIG=${config}"
+    [ ! -z "${haInstance}" ] && [ ! -z "${print}" ] && echo "+ >  haInstance=${haInstance}"
+
+    [ ! -z "${print}" ] && echo "${result}"
+
+    if [ ! -z "${textMatch}" ]; then
+        findText=$(echo "${result}" | grep "${textMatch}" )
+        if [ -z "${findText}" ]; then
+            echo "- >  Not found: ${textMatch}"
+            errors=`expr $errors + 1`
+        fi
+    fi
+
+    [ ! -z "${print}" ] && echo ""
+}
+
+IFS='|'
+while read config haInstace textMatch desc debug; do
+    if [ "${config}" != "CONFIG " ]; then
+        run_launcher $config $haInstace $textMatch $desc $debug 
+    fi
+done <<EOF #! /bin/sh
+EOF
+CONFIG | HA-INSTANCE | TEXT-TO-FIND | DESCRIPTION | ZLDEBUG
+ | | PANIC! readJson got null pathElement | No config lead to PANIC!
+/git/repos/launcher/bin/zowe.yaml | | ZWEL0021I Zowe Launcher starting | Check the basic message ZWEL0021I
+/git/repos/launcher/bin/zowe.yaml | | INFO ZWEL0023I Zowe YAML config file is 'FILE(/git/repos/launcher/bin/zowe.yaml)' | ZWEL0023I wrapped by FILE()
+FILE(/git/repos/launcher/bin/zowe.yaml) | | INFO ZWEL0023I Zowe YAML config file is 'FILE(/git/repos/launcher/bin/zowe.yaml)' | Same as previous test
+FILE(/git/repos/launcher/bin/zowe.yaml) | LPAR123 | ZWEL0024I HA_INSTANCE_ID is 'lpar123' | HaInstance should be sanitazed
+PARMLIB(ZOWE.PR4285.A(A)) | hello | ZWEL0023I Zowe YAML config file is 'PARMLIB(ZOWE.PR4285.A(A))' | Parmlib does not exist, but it should be in ZWEL00203I
+PARMLIB(ZOWE.PR4285.A) | hello | ZWEL0068E PARMLIB() entries must have a member name | Should detect missing member
+PARMLIB(ZOWE.PR4285.A() | hello | ZWEL0068E PARMLIB() entries must have a member name | Should detect missing member
+PARMLIB(ZOWE.PR4285.A()) | hello | ZWEL0068E PARMLIB() entries must have a member name | Should detect missing member
+EOF
+
+exit $errors
+EOF

--- a/test/config-syntax.sh
+++ b/test/config-syntax.sh
@@ -63,8 +63,7 @@ while read config haInstace textMatch desc debug; do
     if [ "${config}" != "CONFIG " ]; then
         run_launcher $config $haInstace $textMatch $desc $debug 
     fi
-done <<EOF #! /bin/sh
-EOF
+done <<EOF
 CONFIG | HA-INSTANCE | TEXT-TO-FIND | DESCRIPTION | ZLDEBUG
  | | PANIC! readJson got null pathElement | No config lead to PANIC!
 /git/repos/launcher/bin/zowe.yaml | | ZWEL0021I Zowe Launcher starting | Check the basic message ZWEL0021I
@@ -78,4 +77,3 @@ PARMLIB(ZOWE.PR4285.A()) | hello | ZWEL0068E PARMLIB() entries must have a membe
 EOF
 
 exit $errors
-EOF

--- a/test/files/zowe.runtime.dev.null.yaml
+++ b/test/files/zowe.runtime.dev.null.yaml
@@ -1,0 +1,4 @@
+zowe:
+  environments:
+    hello: 'World!'
+  runtimeDirectory: /dev/null


### PR DESCRIPTION
Depends upon https://github.com/zowe/zowe-common-c/pull/522

This PR lifts the restriction that PARMLIB entries of the CONFIG argument would need to all have the same member name. Now, they can have whatever valid & existing PDS member name is desired.