### PR TITLE
Optionally trimming the sys messages to print from the sys-message-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zowe Launcher package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 3.3
+- Enhancment: Trimming the sys messages to print from the sys-message-id as optional based on the zowe.sysMessageTrim=true/false. (#147)
+
 ## 3.1
 - Bugfix: HEAPPOOLS and HEAPPOOLS64 no longer need to be set to OFF for launcher (#133)
 

--- a/src/main.c
+++ b/src/main.c
@@ -176,12 +176,13 @@ struct {
   char *root_dir;
   char *workspace_dir;
   JsonArray *sys_messages;
+  bool trim_sys_message;
   char ha_instance_id[64];
   
   pid_t pid;
   char userid[9];
   
-} zl_context = {.config = {.debug_mode = false}, .userid = "(NONE)"} ;
+} zl_context = {.config = {.debug_mode = false}, .trim_sys_message = false, .userid = "(NONE)"} ;
 
 // Wrapper for wtoPrintf3
 static void printf_wto(const char *formatString, ...) {
@@ -203,6 +204,13 @@ static void set_sys_messages(ConfigManager *configmgr) {
   if (sys_messages) {
     zl_context.sys_messages = sys_messages;
   }
+
+  bool trim = false; // for backwards compatibility trimming sys messages is disabled by default.
+  cfgGetStatus = cfgGetBooleanC(configmgr, ZOWE_CONFIG_NAME, &trim, 2, "zowe", "sysMessageTrim");
+  if (cfgGetStatus != ZCFG_SUCCESS) { // No sysMessageTrim found in Zowe configuration, disabled by default.
+    return;
+  }
+  zl_context.trim_sys_message = trim;
 }
 
 static void launcher_syslog_on_match(const char* fmt, ...) {
@@ -221,8 +229,13 @@ static void launcher_syslog_on_match(const char* fmt, ...) {
   int count = jsonArrayGetCount(zl_context.sys_messages);
   for (int i = 0; i < count; i++) {
       const char *sys_message_id = jsonArrayGetString(zl_context.sys_messages, i);
-      if (sys_message_id && strstr(input_string, sys_message_id)) {
-          printf_wto(input_string); // Print our match to the syslog
+      char *sys_message_start = strstr(input_string, sys_message_id);
+      if (sys_message_id && sys_message_start) {
+          if (zl_context.trim_sys_message) {
+            printf_wto(sys_message_start); // Print out match starting from sys message ID
+          } else {
+            printf_wto(input_string); // Print our match to the syslog
+          }
           break;
       }
   }
@@ -265,6 +278,7 @@ static void check_for_and_print_sys_message(const char* input_string) {
   int input_length = strlen(input_string);
   for (int i = 0; i < count; i++) {
     const char *sys_message_id = jsonArrayGetString(zl_context.sys_messages, i);
+    int sys_message_pos = index_of_string_limited(input_string, input_length, sys_message_id, 0, SYSLOG_MESSAGE_LENGTH_LIMIT);
     if (sys_message_id && (index_of_string_limited(input_string, input_length, sys_message_id, 0, SYSLOG_MESSAGE_LENGTH_LIMIT) != -1)) {
 
       //exclude "ZWE_zowe_sysMessages" messages to avoid spam.
@@ -276,6 +290,9 @@ static void check_for_and_print_sys_message(const char* input_string) {
         int regex_rc = regcomp(&time_regex, DATE_PREFIX_REGEXP_PATTERN, 0);
         int match = regexec(&time_regex, input_string, 0, NULL, 0);
         int offset = match == 0 ? DATE_PREFIX_LEN : 0;
+        if (zl_context.trim_sys_message) {
+          offset = sys_message_pos; // Skip and Print syslog message starting from sys message ID
+        }
         int length = SYSLOG_MESSAGE_LENGTH_LIMIT < (input_length-offset) ? SYSLOG_MESSAGE_LENGTH_LIMIT : input_length-offset;
         memcpy(syslog_string, input_string+offset, length);  
         syslog_string[length] = '\0';

--- a/src/main.c
+++ b/src/main.c
@@ -184,6 +184,8 @@ struct {
   
 } zl_context = {.config = {.debug_mode = false}, .trim_sys_message = false, .userid = "(NONE)"} ;
 
+static int index_of_string_limited(const char *, int, const char *, int, int);
+
 // Wrapper for wtoPrintf3
 static void printf_wto(const char *formatString, ...) {
   va_list argPointer;
@@ -213,6 +215,7 @@ static void set_sys_messages(ConfigManager *configmgr) {
   zl_context.trim_sys_message = trim;
 }
 
+
 static void launcher_syslog_on_match(const char* fmt, ...) {
   if (!zl_context.sys_messages) {
     return;
@@ -227,12 +230,13 @@ static void launcher_syslog_on_match(const char* fmt, ...) {
   va_end(args);
     
   int count = jsonArrayGetCount(zl_context.sys_messages);
+  int input_length = strlen(input_string);
   for (int i = 0; i < count; i++) {
       const char *sys_message_id = jsonArrayGetString(zl_context.sys_messages, i);
-      char *sys_message_start = strstr(input_string, sys_message_id);
-      if (sys_message_id && sys_message_start) {
+      int  sys_message_pos = index_of_string_limited(input_string, input_length, sys_message_id, 0, SYSLOG_MESSAGE_LENGTH_LIMIT);
+      if (sys_message_id && (sys_message_pos != -1)) {
           if (zl_context.trim_sys_message) {
-            printf_wto(sys_message_start); // Print out match starting from sys message ID
+            printf_wto(input_string + sys_message_pos); // Print out match starting from sys message ID
           } else {
             printf_wto(input_string); // Print our match to the syslog
           }
@@ -276,20 +280,21 @@ static void check_for_and_print_sys_message(const char* input_string) {
 
   int count = jsonArrayGetCount(zl_context.sys_messages);
   int input_length = strlen(input_string);
+  regex_t time_regex;
+  int regex_rc = regcomp(&time_regex, DATE_PREFIX_REGEXP_PATTERN, 0);
+  int match = regexec(&time_regex, input_string, 0, NULL, 0);
+  int offset = match == 0 ? DATE_PREFIX_LEN : 0;
+
   for (int i = 0; i < count; i++) {
     const char *sys_message_id = jsonArrayGetString(zl_context.sys_messages, i);
     int sys_message_pos = index_of_string_limited(input_string, input_length, sys_message_id, 0, SYSLOG_MESSAGE_LENGTH_LIMIT);
-    if (sys_message_id && (index_of_string_limited(input_string, input_length, sys_message_id, 0, SYSLOG_MESSAGE_LENGTH_LIMIT) != -1)) {
+    if (sys_message_id && (sys_message_pos != -1)) {
 
       //exclude "ZWE_zowe_sysMessages" messages to avoid spam.
       if (memcmp("ZWE_zowe_sysMessages", input_string, ZWE_SYSMESSAGES_EXCLUDE_LEN)){ 
 
         //truncate match for reasonable output
         char syslog_string[SYSLOG_MESSAGE_LENGTH_LIMIT+1] = {0};
-        regex_t time_regex;
-        int regex_rc = regcomp(&time_regex, DATE_PREFIX_REGEXP_PATTERN, 0);
-        int match = regexec(&time_regex, input_string, 0, NULL, 0);
-        int offset = match == 0 ? DATE_PREFIX_LEN : 0;
         if (zl_context.trim_sys_message) {
           offset = sys_message_pos; // Skip and Print syslog message starting from sys message ID
         }


### PR DESCRIPTION
The current logic of the launcher syslog messages is to take the matching line, truncate to 126 characters, and put that in the log.
But that would mostly just show the timestamp & misc information, and very little of the actual message itself.

This PR trims the message so as to start printing from the sys-message-id, as shown below.

Before: 

1. <ZWED:459429> ZWESMVD INFO (_zsf.install,webapp.js:2069) ZWED0068I - Creating composite swagger endpoint for org.zowe.zlux   
2. <ZWED:458986> ZWESMVD INFO (_zsf.install,index.js:353) ZWED0031I - Server is ready at https://XYZ.com:12300/zl

After:

1. ZWED0068I - Creating composite swagger endpoint for org.zowe.zlux.ng2desktop.settings
2. ZWED0031I - Server is ready at https://xyz:12300/zlux/ui/v1/, Plugins successfully loaded: 100(19/19 


Changing that behavior could be seen as disruptive, because of this trimming will be optional based on new configuration parameter "**zowe.sysMessageTrim**". This parameter is introduced through PR: https://github.com/zowe/zowe-install-packaging/pull/4294

This PR addresses Issue: https://github.com/zowe/launcher/issues/143

