### PR TITLE
add cleanup_ipc, run on every component start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe Launcher package will be documented in this file
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.3
-- Enhancement: launcher runs cleanup_ipcmq on every component start (#148)
+- Enhancement: launcher runs cleanup_ipcmq on initial start and every app-server start (#148)
 
 ## 3.1
 - Bugfix: HEAPPOOLS and HEAPPOOLS64 no longer need to be set to OFF for launcher (#133)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zowe Launcher package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 3.3
+- Enhancement: launcher runs cleanup_ipcmq on every component start (#148)
+
 ## 3.1
 - Bugfix: HEAPPOOLS and HEAPPOOLS64 no longer need to be set to OFF for launcher (#133)
 

--- a/src/main.c
+++ b/src/main.c
@@ -908,6 +908,9 @@ static const char **env_comp(zl_comp_t *comp) {
   return env_comp;
 }
 
+// define method signature
+static int cleanup_ipc(void);
+
 static int start_component(zl_comp_t *comp) {
 
   if (comp->pid != -1) {
@@ -916,6 +919,11 @@ static int start_component(zl_comp_t *comp) {
   }
 
   DEBUG("about to start component %s\n", comp->name);
+
+  // run cleanup-ipc before starting the component
+  if(cleanup_ipc()){
+    DEBUG("launcher could not run or complete cleanup ipc\n");
+  }
 
   // ensure the new process has its own process group ID so we can terminate
   // the entire process tree
@@ -1255,7 +1263,7 @@ static void *handle_console(void *args) {
   return NULL;
 }
 
-static int start_console_tread(void) {
+static int start_console_thread(void) {
 
   DEBUG("starting console thread\n");
 
@@ -1777,14 +1785,38 @@ static void print_line(void *data, const char *line) {
   check_for_and_print_sys_message(line);
 }
 
-static char* get_start_prepare_cmd(char *sharedenv) {
-  const char basecmd[] = "%s ZWE_CLI_PARAMETER_CONFIG=\"%s\" %s/bin/utils/configmgr -script %s/bin/commands/internal/start/prepare/cli.js 2>&1";
-  int size = (strlen(zl_context.root_dir) * 2) + strlen(zl_context.config_path) + strlen(sharedenv) + sizeof(basecmd) + 1;
+static char* get_command(char* sharedenv, const char* basecmd) {
+  int size = (strlen(zl_context.root_dir) * 2) + strlen(zl_context.config_path) + strlen(sharedenv) + strlen(basecmd) + 1; 
   char *command = malloc(size);
 
   snprintf(command, size, basecmd,
            sharedenv, zl_context.config_path, zl_context.root_dir, zl_context.root_dir);
   return command;
+}
+
+static char* get_cleanup_ipc_cmd(char* sharedenv) {
+  const char basecmd[] = "%s ZWE_CLI_PARAMETER_CONFIG=\"%s\" %s/bin/utils/configmgr -script %s/bin/commands/internal/utils/cleanup-ipcmq/cli.js 2>&1";
+  return get_command(sharedenv, basecmd);
+}
+
+static char* get_start_prepare_cmd(char *sharedenv) {
+  const char basecmd[] = "%s ZWE_CLI_PARAMETER_CONFIG=\"%s\" %s/bin/utils/configmgr -script %s/bin/commands/internal/start/prepare/cli.js 2>&1";
+  return get_command(sharedenv, basecmd);
+}
+
+static int cleanup_ipc() {
+  char *sharedenv = get_sharedenv();
+  char *command = get_cleanup_ipc_cmd(sharedenv);
+
+  free(sharedenv);
+
+  DEBUG("about to cleanup IPC queue\n");
+  if (run_command(command, print_line, NULL)) {
+    DEBUG(MSG_IPC_CLEANUP_FAILED);
+    return -1;
+  }
+  DEBUG(MSG_IPC_CLEANUP_SUCCESS);
+  return 0;
 }
 
 static int prepare_instance() {
@@ -1959,7 +1991,7 @@ int main(int argc, char **argv) {
 
   start_components();
 
-  if (start_console_tread()) {
+  if (start_console_thread()) {
     ERROR(MSG_CONS_START_ERR);
     free(shared_uss_env);
     exit(EXIT_FAILURE);

--- a/src/main.c
+++ b/src/main.c
@@ -920,9 +920,11 @@ static int start_component(zl_comp_t *comp) {
 
   DEBUG("about to start component %s\n", comp->name);
 
-  // run cleanup-ipc before starting the component
-  if(cleanup_ipc()){
-    DEBUG("launcher could not run or complete cleanup ipc\n");
+  // run cleanup-ipc before starting the app-server
+  if (strncmp(comp->name, "app-server", 12)) {
+    if(cleanup_ipc()){
+      DEBUG("launcher could not run or complete cleanup ipc\n");
+    }
   }
 
   // ensure the new process has its own process group ID so we can terminate
@@ -1811,11 +1813,12 @@ static int cleanup_ipc() {
   free(sharedenv);
 
   DEBUG("about to cleanup IPC queue\n");
-  if (run_command(command, print_line, NULL)) {
-    DEBUG(MSG_IPC_CLEANUP_FAILED);
+  int run_rc = run_command(command, print_line, NULL);
+  if (run_rc != 0) {
+    DEBUG("ipc cleanup command failed, rc=%d\n", run_rc);
     return -1;
   }
-  DEBUG(MSG_IPC_CLEANUP_SUCCESS);
+  INFO(MSG_IPC_CLEANUP_SUCCESS);
   return 0;
 }
 

--- a/src/msg.h
+++ b/src/msg.h
@@ -87,6 +87,8 @@
 #define MSG_CFG_LOAD_FAIL       MSG_PREFIX "0072E" " Launcher Could not load configurations\n"
 #define MSG_CFG_SCHEMA_FAIL     MSG_PREFIX "0073E" " Launcher Could not load schemas, status=%d\n"
 #define MSG_NO_LOG_CONTEXT      MSG_PREFIX "0074E" " Log context was not created\n"
+#define MSG_IPC_CLEANUP_FAILED  MSG_PREFIX "0075D" " Automatic IPC Cleanup Failed.\n"
+#define MSG_IPC_CLEANUP_SUCCESS MSG_PREFIX "0076D" " Automatic IPC Cleanup Succeeded.\n"
 #define MSG_LINE_LENGTH         "-- If you cant see '500' at the end of the line, your log is too short to read!80--------90------ 100----------------------125----------------------150----------------------175----------------------200----------------------225----------------------250----------------------275----------------------300----------------------325----------------------350----------------------375----------------------400----------------------425----------------------450----------------------475----------------------500\n"
 
 #endif // MSG_H

--- a/src/msg.h
+++ b/src/msg.h
@@ -87,8 +87,7 @@
 #define MSG_CFG_LOAD_FAIL       MSG_PREFIX "0072E" " Launcher Could not load configurations\n"
 #define MSG_CFG_SCHEMA_FAIL     MSG_PREFIX "0073E" " Launcher Could not load schemas, status=%d\n"
 #define MSG_NO_LOG_CONTEXT      MSG_PREFIX "0074E" " Log context was not created\n"
-#define MSG_IPC_CLEANUP_FAILED  MSG_PREFIX "0075D" " Automatic IPC Cleanup Failed.\n"
-#define MSG_IPC_CLEANUP_SUCCESS MSG_PREFIX "0076D" " Automatic IPC Cleanup Succeeded.\n"
+#define MSG_IPC_CLEANUP_SUCCESS MSG_PREFIX "0075I" " Automatic IPC Cleanup Succeeded.\n"
 #define MSG_LINE_LENGTH         "-- If you cant see '500' at the end of the line, your log is too short to read!80--------90------ 100----------------------125----------------------150----------------------175----------------------200----------------------225----------------------250----------------------275----------------------300----------------------325----------------------350----------------------375----------------------400----------------------425----------------------450----------------------475----------------------500\n"
 
 #endif // MSG_H
@@ -1081,6 +1080,18 @@
 //@  **Reason:**
 //@
 //@  The command `<command>` ended with return code `<return-code>`.
+//@
+//@  **Action:**
+//@
+//@  No action required.
+//@
+// #define MSG_IPC_CLEANUP_SUCCESS MSG_PREFIX "0075I" " Automatic IPC Cleanup Succeeded.\n"
+//@
+//@  Automatic IPC Cleanup Succeeded.
+//@
+//@  **Reason:**
+//@
+//@  Automatic IPC cleanup was triggered as part of app-server start or restart, and succeeded.
 //@
 //@  **Action:**
 //@


### PR DESCRIPTION
Addresses https://github.com/zowe/zowe-install-packaging/issues/3444 

Requires PR in zowe-install-packaging: https://github.com/zowe/zowe-install-packaging/pull/4305 

The launcher now runs a `cleanup_ipcmq()` function which invokes a new zwe command to clean up IPC MQ as part of ~every component's~ the app-server's start process. The `internal start prepare` command continues to run the cleanup ipcmq script as well to preserve existing behavior. All in all, the new behavior is this:

* On first startup, Zowe runs the ipcmq script 2 times. Once for the app-server, and once as part of internal start prepare.
*  On app-server start via recovery, or modify=stop/start, we will cleanup ipc mq.