### PR TITLE
[DO NOT MERGE] sys messages were not duplicated because the sys-message-id appeared after 126-character length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 ## 3.3
 - Enhancement: Launcher can now accept PARMLIB CONFIG entries that have more than one member name ([#146](https://github.com/zowe/launcher/pull/146))
 - Enhancement: Trimming the sys messages to print from the sys-message-id as optional based on the zowe.sysMessageTrim=true/false. (#147)
-- Bugfix: Resolved an issue introduced in PR #147 where certain system messages were not duplicated because the sys-message-id appeared beyond the 126-character prefix limit. (#149) 
+- Bugfix: Resolved an issue introduced in PR #147 where certain system messages were not duplicated because the sys-message-id appeared beyond the 126-character prefix limit. (#156) 
 
 ## 3.1
 - Bugfix: HEAPPOOLS and HEAPPOOLS64 no longer need to be set to OFF for launcher (#133)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 ## 3.3
 - Enhancement: Launcher can now accept PARMLIB CONFIG entries that have more than one member name ([#146](https://github.com/zowe/launcher/pull/146))
 - Enhancement: Trimming the sys messages to print from the sys-message-id as optional based on the zowe.sysMessageTrim=true/false. (#147)
+- Bugfix: Resolved an issue introduced in PR #147 where certain system messages were not duplicated because the sys-message-id appeared beyond the 126-character prefix limit. (#149) 
 
 ## 3.1
 - Bugfix: HEAPPOOLS and HEAPPOOLS64 no longer need to be set to OFF for launcher (#133)

--- a/src/main.c
+++ b/src/main.c
@@ -232,7 +232,8 @@ static void launcher_syslog_on_match(const char* fmt, ...) {
   int input_length = strlen(input_string);
   for (int i = 0; i < count; i++) {
       const char *sys_message_id = jsonArrayGetString(zl_context.sys_messages, i);
-      int  sys_message_pos = index_of_string_limited(input_string, input_length, sys_message_id, 0, SYSLOG_MESSAGE_LENGTH_LIMIT);
+      char *sys_message_start = strstr(input_string, sys_message_id);
+      int sys_message_pos = (sys_message_start != NULL) ? (sys_message_start - input_string) : -1;
       if (sys_message_id && (sys_message_pos != -1)) {
           if (zl_context.trim_sys_message) {
             printf_wto(input_string + sys_message_pos); // Print out match starting from sys message ID


### PR DESCRIPTION
Issue:
===
Some messages have very long prefix, such as ZWEAM001I. In this specific example, the match ID is on position 162, the position is never found by index_of_string_limited:

 ...+....10...+....20...+....30. ... 0..+....170..+....180..+....190..+...
2025-05-27 13:47:23.844 <ZWEAGW1 ... ZWEAM001I API Mediation Layer started

Looks like PR: https://github.com/zowe/launcher/pull/147/files didnt cause this issue, the behavior was already there, root cause needs to be found.

Relates to issue: https://github.com/zowe/launcher/issues/155