### PR TITLE
`zowe.sysMessages`: common function for launcher and other messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zowe Launcher package will be documented in this file
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.3
+- Bugfix: `zowe.sysMessages` feature was ignoring messages where the matching string was after the position of 126 ([#158]https://github.com/zowe/launcher/pull/158)
 - Enhancement: Launcher can now accept PARMLIB CONFIG entries that have more than one member name ([#146](https://github.com/zowe/launcher/pull/146))
 - Enhancement: Trimming the sys messages to print from the sys-message-id as optional based on the zowe.sysMessageTrim=true/false. (#147)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe Launcher package will be documented in this file
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.3
-- Bugfix: `zowe.sysMessages` feature was ignoring messages where the matching string was after the position of 126 ([#158]https://github.com/zowe/launcher/pull/158)
+- Bugfix: `zowe.sysMessages` feature was ignoring messages where the matching string was after the position of 126 ([#157]https://github.com/zowe/launcher/pull/157)
 - Enhancement: Launcher can now accept PARMLIB CONFIG entries that have more than one member name ([#146](https://github.com/zowe/launcher/pull/146))
 - Enhancement: Trimming the sys messages to print from the sys-message-id as optional based on the zowe.sysMessageTrim=true/false. (#147)
 

--- a/src/main.c
+++ b/src/main.c
@@ -217,10 +217,7 @@ static void set_sys_messages(ConfigManager *configmgr) {
 #define ZWE_ZOWE_SYS_MESSAGES_LEN (sizeof(ZWE_ZOWE_SYS_MESSAGES) - 1)
 
 static bool check_match_and_wto_message(const char* sys_message_id, const char* input_string, const bool other_messages) {
-  // sysMessages could possibly contain null item
-  if (!sys_message_id) {
-    return false;
-  }
+
   char *sys_message_start = strstr(input_string, sys_message_id);
   int sys_message_pos = (sys_message_start != NULL) ? (sys_message_start - input_string) : -1;
   if (sys_message_pos == -1) {

--- a/src/main.c
+++ b/src/main.c
@@ -183,8 +183,6 @@ struct {
   
 } zl_context = {.config = {.debug_mode = false}, .trim_sys_message = false, .userid = "(NONE)"} ;
 
-static int index_of_string_limited(const char *, int, const char *, int, int);
-
 // Wrapper for wtoPrintf3
 static void printf_wto(const char *formatString, ...) {
   va_list argPointer;
@@ -214,7 +212,49 @@ static void set_sys_messages(ConfigManager *configmgr) {
   zl_context.trim_sys_message = trim;
 }
 
+static bool check_match_in_message(const char* sys_message_id, const char* input_string, const bool other_messages) {
+  char *sys_message_start = strstr(input_string, sys_message_id);
+  int sys_message_pos = (sys_message_start != NULL) ? (sys_message_start - input_string) : -1;
+  if (sys_message_pos == -1) {
+    return false;
+  }
+  int input_string_len = strlen(input_string);
 
+  if (other_messages) {
+    // App-server: "Show Environment"
+    // E.g.ZWE_zowe_sysMessages_0=ZWEL0021I
+    if (memcmp("ZWE_zowe_sysMessages", input_string, ZWE_SYSMESSAGES_EXCLUDE_LEN) == 0) {
+      return 0;
+    }
+    // App-server: ZWED5015I prints config as json
+    // All zowe.sysMessages are printed, this is trying to ignore it
+    // Eg: |     "ZWED0031I",| -> strlen("ZWED0031I") + 9 extra characters
+    if (input_string_len <= strlen(sys_message_id) + 9) {
+      return false;
+    }
+  }
+
+  if (sys_message_id) {
+    if (zl_context.trim_sys_message) {
+      printf_wto(input_string + sys_message_pos); // Print out match starting from sys message ID
+    } else {
+      if (input_string_len <= WTO_MESSAGE_LENGTH) {  // Directly wto entire message
+        printf_wto(input_string);
+      } else {
+        if (input_string_len - sys_message_pos > WTO_MESSAGE_LENGTH) {
+          printf_wto(input_string + sys_message_pos);
+        } else {
+          printf_wto(input_string + (input_string_len - WTO_MESSAGE_LENGTH));
+        }
+      }
+    }
+    return true;
+  }
+
+  return false;
+}
+
+// Launcher's message contains the body only, no timestamp
 static void launcher_syslog_on_match(const char* fmt, ...) {
   if (!zl_context.sys_messages) {
     return;
@@ -227,39 +267,15 @@ static void launcher_syslog_on_match(const char* fmt, ...) {
   va_start(args, fmt);
   vsnprintf(input_string, sizeof(input_string), fmt, args);
   va_end(args);
-    
+
   int count = jsonArrayGetCount(zl_context.sys_messages);
-  int input_length = strlen(input_string);
   for (int i = 0; i < count; i++) {
-      const char *sys_message_id = jsonArrayGetString(zl_context.sys_messages, i);
-      int  sys_message_pos = index_of_string_limited(input_string, input_length, sys_message_id, 0, SYSLOG_MESSAGE_LENGTH_LIMIT);
-      if (sys_message_id && (sys_message_pos != -1)) {
-          if (zl_context.trim_sys_message) {
-            printf_wto(input_string + sys_message_pos); // Print out match starting from sys message ID
-          } else {
-            printf_wto(input_string); // Print our match to the syslog
-          }
-          break;
-      }
-  }
-  
-}
-
-static int index_of_string_limited(const char *str, int len, const char *search_string, int start_pos, int search_limit){
-  int search_len = strlen(search_string);
-  int last_possible_start = len < search_limit ? len - search_len : search_limit - search_len;
-  int pos = start_pos;
-
-  if (start_pos > last_possible_start){
-    return -1;
-  }
-  while (pos <= last_possible_start){
-    if (!memcmp(str+pos,search_string,search_len)){
-      return pos;
+    const char *sys_message_id = jsonArrayGetString(zl_context.sys_messages, i);
+    if (check_match_in_message(sys_message_id, input_string, false)) {
+      break;
     }
-    pos++;
   }
-  return -1;
+
 }
 
 //size of "ZWE_zowe_sysMessages"
@@ -272,13 +288,13 @@ static int index_of_string_limited(const char *str, int len, const char *search_
 // zowe standard "YYYY-MM-DD HH-MM-SS.sss "
 #define DATE_PREFIX_LEN 24
 
+// Other messages are completed, check possible date and filter it out
 static void check_for_and_print_sys_message(const char* input_string) {
   if (!zl_context.sys_messages) {
     return;
   }
 
   int count = jsonArrayGetCount(zl_context.sys_messages);
-  int input_length = strlen(input_string);
   regex_t time_regex;
   int regex_rc = regcomp(&time_regex, DATE_PREFIX_REGEXP_PATTERN, 0);
   int match = regexec(&time_regex, input_string, 0, NULL, 0);
@@ -286,23 +302,8 @@ static void check_for_and_print_sys_message(const char* input_string) {
 
   for (int i = 0; i < count; i++) {
     const char *sys_message_id = jsonArrayGetString(zl_context.sys_messages, i);
-    int sys_message_pos = index_of_string_limited(input_string, input_length, sys_message_id, 0, SYSLOG_MESSAGE_LENGTH_LIMIT);
-    if (sys_message_id && (sys_message_pos != -1)) {
-
-      //exclude "ZWE_zowe_sysMessages" messages to avoid spam.
-      if (memcmp("ZWE_zowe_sysMessages", input_string, ZWE_SYSMESSAGES_EXCLUDE_LEN)){ 
-
-        //truncate match for reasonable output
-        char syslog_string[SYSLOG_MESSAGE_LENGTH_LIMIT+1] = {0};
-        if (zl_context.trim_sys_message) {
-          offset = sys_message_pos; // Skip and Print syslog message starting from sys message ID
-        }
-        int length = SYSLOG_MESSAGE_LENGTH_LIMIT < (input_length-offset) ? SYSLOG_MESSAGE_LENGTH_LIMIT : input_length-offset;
-        memcpy(syslog_string, input_string+offset, length);  
-        syslog_string[length] = '\0';
-        printf_wto(syslog_string);// Print our match to the syslog
-        break;
-      }
+    if (check_match_in_message(sys_message_id, input_string + offset, true)) {
+      break;
     }
   }
   

--- a/src/main.c
+++ b/src/main.c
@@ -244,12 +244,19 @@ static bool check_match_and_wto_message(const char* sys_message_id, const char* 
   if (zl_context.trim_sys_message) {
     printf_wto(input_string + sys_message_pos);
   } else {
+    // Short message, WTO *
     if (input_string_len <= WTO_MESSAGE_LENGTH) {
       printf_wto(input_string);
+    // Message length > WTO_MESSAGE_LENGTH
     } else {
+      // After the match, there are more chars than WTO_MESSAGE_LENGTH
+      // WTO from match position
       if (input_string_len - sys_message_pos > WTO_MESSAGE_LENGTH) {
         printf_wto(input_string + sys_message_pos);
       } else {
+        // The match is in the last WTO_MESSAGE_LENGTH chars
+        // WTO last WTO_MESSAGE_LENGTH chars - egde case: if the match is last word
+        //   user will see the text before match too
         printf_wto(input_string + (input_string_len - WTO_MESSAGE_LENGTH));
       }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -215,6 +215,9 @@ static void set_sys_messages(ConfigManager *configmgr) {
 //size of "ZWE_zowe_sysMessages"
 #define ZWE_ZOWE_SYS_MESSAGES "ZWE_zowe_sysMessages"
 #define ZWE_ZOWE_SYS_MESSAGES_LEN (sizeof(ZWE_ZOWE_SYS_MESSAGES) - 1)
+// App-server: ZWED5015I prints config as json
+// All zowe.sysMessages are printed, E.g. ^      "ZWED0031I",$
+#define ZWED5015I_JSON_CONFIG_EXTRA_CHARACTERS (sizeof("      \"\",") - 1)
 
 static bool check_match_and_wto_message(const char* sys_message_id, const char* input_string, const bool other_messages) {
 
@@ -226,15 +229,12 @@ static bool check_match_and_wto_message(const char* sys_message_id, const char* 
   int input_string_len = strlen(input_string);
 
   if (other_messages) {
-    // App-server: "Show Environment"
-    // E.g.ZWE_zowe_sysMessages_0=ZWEL0021I
+    // App-server -> Show Environment -> E.g. ^ZWE_zowe_sysMessages_0=ZWEL0021I$
     if (memcmp(ZWE_ZOWE_SYS_MESSAGES, input_string, ZWE_ZOWE_SYS_MESSAGES_LEN) == 0) {
       return 0;
     }
-    // App-server: ZWED5015I prints config as json
-    // All zowe.sysMessages are printed, this is trying to ignore it
-    // Eg: |     "ZWED0031I",| -> strlen("ZWED0031I") + 9 extra characters
-    if (input_string_len <= strlen(sys_message_id) + 9) {
+    // Try to ignore short message
+    if (input_string_len <= strlen(sys_message_id) + ZWED5015I_JSON_CONFIG_EXTRA_CHARACTERS) {
       return false;
     }
   }

--- a/src/main.c
+++ b/src/main.c
@@ -217,6 +217,10 @@ static void set_sys_messages(ConfigManager *configmgr) {
 #define ZWE_ZOWE_SYS_MESSAGES_LEN (sizeof(ZWE_ZOWE_SYS_MESSAGES) - 1)
 
 static bool check_match_in_message(const char* sys_message_id, const char* input_string, const bool other_messages) {
+  // sysMessages could possibly contain null item
+  if (!sys_message_id) {
+    return false;
+  }
   char *sys_message_start = strstr(input_string, sys_message_id);
   int sys_message_pos = (sys_message_start != NULL) ? (sys_message_start - input_string) : -1;
   if (sys_message_pos == -1) {
@@ -238,24 +242,20 @@ static bool check_match_in_message(const char* sys_message_id, const char* input
     }
   }
 
-  if (sys_message_id) {
-    if (zl_context.trim_sys_message) {
-      printf_wto(input_string + sys_message_pos); // Print out match starting from sys message ID
+  if (zl_context.trim_sys_message) {
+    printf_wto(input_string + sys_message_pos);
+  } else {
+    if (input_string_len <= WTO_MESSAGE_LENGTH) {
+      printf_wto(input_string);
     } else {
-      if (input_string_len <= WTO_MESSAGE_LENGTH) {  // Directly wto entire message
-        printf_wto(input_string);
+      if (input_string_len - sys_message_pos > WTO_MESSAGE_LENGTH) {
+        printf_wto(input_string + sys_message_pos);
       } else {
-        if (input_string_len - sys_message_pos > WTO_MESSAGE_LENGTH) {
-          printf_wto(input_string + sys_message_pos);
-        } else {
-          printf_wto(input_string + (input_string_len - WTO_MESSAGE_LENGTH));
-        }
+        printf_wto(input_string + (input_string_len - WTO_MESSAGE_LENGTH));
       }
     }
-    return true;
   }
-
-  return false;
+  return true;
 }
 
 // Launcher's message contains the body only, no timestamp

--- a/src/main.c
+++ b/src/main.c
@@ -286,6 +286,9 @@ static void launcher_syslog_on_match(const char* fmt, ...) {
 // zowe standard "YYYY-MM-DD HH-MM-SS.sss "
 #define DATE_PREFIX_LEN 24
 
+// Needed once
+static regex_t time_regex = { .re_comp = NULL };
+
 // Other messages are completed, check possible date and filter it out
 static void check_for_and_print_sys_message(const char* input_string) {
   if (!zl_context.sys_messages) {
@@ -294,7 +297,9 @@ static void check_for_and_print_sys_message(const char* input_string) {
 
   int count = jsonArrayGetCount(zl_context.sys_messages);
   regex_t time_regex;
-  int regex_rc = regcomp(&time_regex, DATE_PREFIX_REGEXP_PATTERN, 0);
+  if (!time_regex.re_comp) {
+    int regex_rc = regcomp(&time_regex, DATE_PREFIX_REGEXP_PATTERN, 0);
+  }
   int match = regexec(&time_regex, input_string, 0, NULL, 0);
   int offset = match == 0 ? DATE_PREFIX_LEN : 0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -215,9 +215,10 @@ static void set_sys_messages(ConfigManager *configmgr) {
 //size of "ZWE_zowe_sysMessages"
 #define ZWE_ZOWE_SYS_MESSAGES "ZWE_zowe_sysMessages"
 #define ZWE_ZOWE_SYS_MESSAGES_LEN (sizeof(ZWE_ZOWE_SYS_MESSAGES) - 1)
-// App-server: ZWED5015I prints config as json
-// All zowe.sysMessages are printed, E.g. ^      "ZWED0031I",$
+/* App-server: ZWED5015I prints config as json
+All zowe.sysMessages are printed, e.g. ^      "ZWED0031I",$
 #define ZWED5015I_JSON_CONFIG_EXTRA_CHARACTERS (sizeof("      \"\",") - 1)
+*/
 
 static bool check_match_and_wto_message(const char* sys_message_id, const char* input_string, const bool other_messages) {
 
@@ -233,10 +234,11 @@ static bool check_match_and_wto_message(const char* sys_message_id, const char* 
     if (memcmp(ZWE_ZOWE_SYS_MESSAGES, input_string, ZWE_ZOWE_SYS_MESSAGES_LEN) == 0) {
       return 0;
     }
-    // Try to ignore short message
+    /* TODO: Try to ignore messages, which are short and probably output of ZWED5015I
     if (input_string_len <= strlen(sys_message_id) + ZWED5015I_JSON_CONFIG_EXTRA_CHARACTERS) {
       return false;
     }
+    */
   }
 
   if (zl_context.trim_sys_message) {

--- a/src/main.c
+++ b/src/main.c
@@ -232,7 +232,7 @@ static bool check_match_and_wto_message(const char* sys_message_id, const char* 
   if (other_messages) {
     // App-server -> Show Environment -> E.g. ^ZWE_zowe_sysMessages_0=ZWEL0021I$
     if (memcmp(ZWE_ZOWE_SYS_MESSAGES, input_string, ZWE_ZOWE_SYS_MESSAGES_LEN) == 0) {
-      return 0;
+      return false;
     }
     /* TODO: Try to ignore messages, which are short and probably output of ZWED5015I
     if (input_string_len <= strlen(sys_message_id) + ZWED5015I_JSON_CONFIG_EXTRA_CHARACTERS) {

--- a/src/main.c
+++ b/src/main.c
@@ -216,7 +216,7 @@ static void set_sys_messages(ConfigManager *configmgr) {
 #define ZWE_ZOWE_SYS_MESSAGES "ZWE_zowe_sysMessages"
 #define ZWE_ZOWE_SYS_MESSAGES_LEN (sizeof(ZWE_ZOWE_SYS_MESSAGES) - 1)
 
-static bool check_match_in_message(const char* sys_message_id, const char* input_string, const bool other_messages) {
+static bool check_match_and_wto_message(const char* sys_message_id, const char* input_string, const bool other_messages) {
   // sysMessages could possibly contain null item
   if (!sys_message_id) {
     return false;
@@ -275,7 +275,7 @@ static void launcher_syslog_on_match(const char* fmt, ...) {
   int count = jsonArrayGetCount(zl_context.sys_messages);
   for (int i = 0; i < count; i++) {
     const char *sys_message_id = jsonArrayGetString(zl_context.sys_messages, i);
-    if (check_match_in_message(sys_message_id, input_string, false)) {
+    if (check_match_and_wto_message(sys_message_id, input_string, false)) {
       break;
     }
   }
@@ -303,7 +303,7 @@ static void check_for_and_print_sys_message(const char* input_string) {
 
   for (int i = 0; i < count; i++) {
     const char *sys_message_id = jsonArrayGetString(zl_context.sys_messages, i);
-    if (check_match_in_message(sys_message_id, input_string + offset, true)) {
+    if (check_match_and_wto_message(sys_message_id, input_string + offset, true)) {
       break;
     }
   }

--- a/src/main.c
+++ b/src/main.c
@@ -296,7 +296,6 @@ static void check_for_and_print_sys_message(const char* input_string) {
   }
 
   int count = jsonArrayGetCount(zl_context.sys_messages);
-  regex_t time_regex;
   if (!time_regex.re_comp) {
     int regex_rc = regcomp(&time_regex, DATE_PREFIX_REGEXP_PATTERN, 0);
   }

--- a/src/main.c
+++ b/src/main.c
@@ -68,7 +68,7 @@ extern char ** environ;
 #define COMP_LIST_SIZE 1024
 
 #define LAUNCHER_MESSAGE_LENGTH_LIMIT 512
-#define SYSLOG_MESSAGE_LENGTH_LIMIT 126
+#define WTO_MESSAGE_LENGTH 126
 
 #ifndef PATH_MAX
 #define PATH_MAX _POSIX_PATH_MAX
@@ -212,6 +212,10 @@ static void set_sys_messages(ConfigManager *configmgr) {
   zl_context.trim_sys_message = trim;
 }
 
+//size of "ZWE_zowe_sysMessages"
+#define ZWE_ZOWE_SYS_MESSAGES "ZWE_zowe_sysMessages"
+#define ZWE_ZOWE_SYS_MESSAGES_LEN (sizeof(ZWE_ZOWE_SYS_MESSAGES) - 1)
+
 static bool check_match_in_message(const char* sys_message_id, const char* input_string, const bool other_messages) {
   char *sys_message_start = strstr(input_string, sys_message_id);
   int sys_message_pos = (sys_message_start != NULL) ? (sys_message_start - input_string) : -1;
@@ -223,7 +227,7 @@ static bool check_match_in_message(const char* sys_message_id, const char* input
   if (other_messages) {
     // App-server: "Show Environment"
     // E.g.ZWE_zowe_sysMessages_0=ZWEL0021I
-    if (memcmp("ZWE_zowe_sysMessages", input_string, ZWE_SYSMESSAGES_EXCLUDE_LEN) == 0) {
+    if (memcmp(ZWE_ZOWE_SYS_MESSAGES, input_string, ZWE_ZOWE_SYS_MESSAGES_LEN) == 0) {
       return 0;
     }
     // App-server: ZWED5015I prints config as json
@@ -277,9 +281,6 @@ static void launcher_syslog_on_match(const char* fmt, ...) {
   }
 
 }
-
-//size of "ZWE_zowe_sysMessages"
-#define ZWE_SYSMESSAGES_EXCLUDE_LEN 20
 
 // matches YYYY-MM-DD starting with 2xxx.
 // this regex was chosen because other patterns didnt seem to work with LE's regex library.


### PR DESCRIPTION
## Fixes
* #155 

## Changes
* New function `check_match_and_wto_message`
  * This function is common for `launcher_syslog_on_match` and `check_for_and_print_sys_message`
  * Those function are very similar, most of the commom code was moved to one place
* Deleted function `index_of_string_limited`

## Functionality of `check_match_and_wto_message`
* For other (not from launcher) messages check ~`ZWED5015I` and~ `ZWE_zowe_sysMessages`
  * This is coming from `app-server`, which could be restarted, unfortunately we have to check it always or include some extra logic
  * `ZWE_zowe_sysMessages` was already there
  * ~`ZWED5015I` is new~
* If trim is requested, find the position of match, `wto` and end
* Otherwise search in entire message and based on the position of match try to `wto` the maximum of information:
  * If the match is the last word in the message, `wto` last 126 bytes to provide maximum possible information
* No check how long is the message for `wto`, this is done in the `wto` function

### ~`ZWED5015I`~
~Config in JSON format will trigger the WTO as the match is printed to the log, more details [here](https://github.com/zowe/launcher/issues/131).~

~The check for this is as simple as possible, trying to filter out messages with match and short length. Because user can redefine the format of API ML messages, it is possible to have the match in the beginning. Checking the length is more likely to filter out result of `ZWED5015I`.~

## Testing 
### `sysMessages`
```yaml
zowe:
  sysMessages:
    - "ZWEL0021I"
    - "ZWEL0018I"
    - "ZWEL0006I"
    - "ZWES1601I"
    - "ZWEL0008I"
    - "ZWEL0022I"
    - "ZWEL0001I"
    - "ZWEL0002I"
    - "ZWEAM000I"
    - "ZWED0031I"
    - "ZWES1013I"
    - "ZWEAM001I"
    - ~
    - "Hello, world!"
```
### Syslog
```
ZWEL0021I Zowe Launcher starting
ZWEL0018I Zowe instance prepared successfully
ZWEL0006I starting components
ZWEL0001I component gateway started
ZWEL0001I component zaas started
ZWEL0001I component api-catalog started
ZWEL0001I component discovery started
ZWEL0001I component app-server started
ZWEL0001I component zss started
ZWES1013I ZSS Server has started. Version '3.3.0+20250108' 64-bit
VUSR.[0;39m .[36mINFO .[0;39m ((o.z.a.p.s.ServiceStartupEventHandler)) ZWEAM000I API Catalog Service started in 31.331 seconds
ESVUSR.[0;39m .[36mINFO .[0;39m ((o.z.a.p.s.ServiceStartupEventHandler)) ZWEAM000I Discovery Service started in 34.678 seconds
 ZWED0031I - Server is ready at https://example-of-looong-address.com:1234/zlux/ui/v1/, Plugins successfully loaded 100(19/19)
2297> .[35mZWESVUSR.[0;39m .[36mINFO .[0;39m ((o.z.a.p.s.ServiceStartupEventHandler)) ZWEAM000I ZAAS started in 94.911 seconds
0:50725421> .[35mZWESVUSR.[0;39m .[36mINFO .[0;39m ((o.z.a.g.c.GatewayHealthIndicator)) ZWEAM001I API Mediation Layer started
ZWES1601I Server is ready to accept JWT with fallback to legacy tokens
```

Same with `zowe.sysMessageTrim=true`
```
ZWEL0021I Zowe Launcher starting
ZWEL0018I Zowe instance prepared successfully
ZWEL0006I starting components
ZWEL0001I component gateway started
ZWEL0001I component zaas started
ZWEL0001I component api-catalog started
ZWEL0001I component discovery started
ZWEL0001I component app-server started
ZWEL0001I component zss started
ZWES1013I ZSS Server has started. Version '3.3.0+20250108' 64-bit
ZWEAM000I API Catalog Service started in 46.326 seconds
ZWEAM000I Discovery Service started in 49.964 seconds
ZWED0031I - Server is ready at https://example-of-looong-address.com:1234/zlux/ui/v1/, Plugins successfully loaded: 100(19/19)
ZWEAM000I ZAAS started in 113.535 seconds
ZWEAM001I API Mediation Layer started
ZWES1601I Server is ready to accept JWT with fallback to legacy tokens
```

## Notes
`ZLDEBUG` is producing yaml parsing debug output, for example:
```
     sysMessages:                
       SequenceStart (block)     
         Scalar: (len=9)ZWEL0021I
         Scalar: (len=9)ZWEL0018I
         Scalar: (len=9)ZWEL0006I
```

However it seems, this is done before the `sysMessages` check is active.

## Update
* After `sysMessages` [update](https://github.com/zowe/zowe-install-packaging/pull/4362), [no check](https://github.com/zowe/launcher/pull/157/commits/682772c02d786360ca38a4fbaaec922b7abd05fb) if match defined.