### PR TITLE
Print version in `ZWEL0021I Zowe Launcher starting <version>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe Launcher package will be documented in this file
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.4.0
-- Enhancement: Message `ZWEL0021I` includes the version of launcher ([#167][https://github.com/zowe/launcher/pull/167])
+- Enhancement: Message `ZWEL0021I` includes the version of launcher ([#167](https://github.com/zowe/launcher/pull/167]))
 
 ## 3.3.0
 - Bugfix: `zowe.sysMessages` feature was ignoring messages where the matching string was after the position of 126 ([#157](https://github.com/zowe/launcher/pull/157))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,16 @@
 All notable changes to the Zowe Launcher package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
-## 3.3
-- Bugfix: `zowe.sysMessages` feature was ignoring messages where the matching string was after the position of 126 ([#157]https://github.com/zowe/launcher/pull/157)
+## 3.4.0
+- Enhancement: Message `ZWEL0021I` includes the version of launcher ([#???][https://github.com/zowe/launcher/pull/???])
+
+## 3.3.0
+- Bugfix: `zowe.sysMessages` feature was ignoring messages where the matching string was after the position of 126 ([#157](https://github.com/zowe/launcher/pull/157))
 - Enhancement: Launcher can now accept PARMLIB CONFIG entries that have more than one member name ([#146](https://github.com/zowe/launcher/pull/146))
 - Enhancement: Trimming the sys messages to print from the sys-message-id as optional based on the zowe.sysMessageTrim=true/false. (#147)
 - Enhancement: Avoid starting individual apiml components when apiml modulith is enabled ([#160](https://github.com/zowe/launcher/pull/160))
 
-## 3.1
+## 3.1.0
 - Bugfix: HEAPPOOLS and HEAPPOOLS64 no longer need to be set to OFF for launcher (#133)
 
 ## 2.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe Launcher package will be documented in this file
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.4.0
-- Enhancement: Message `ZWEL0021I` includes the version of launcher ([#167](https://github.com/zowe/launcher/pull/167]))
+- Enhancement: Message `ZWEL0021I` includes the version of launcher ([#167](https://github.com/zowe/launcher/pull/167))
 
 ## 3.3.0
 - Bugfix: `zowe.sysMessages` feature was ignoring messages where the matching string was after the position of 126 ([#157](https://github.com/zowe/launcher/pull/157))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe Launcher package will be documented in this file
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.4.0
-- Enhancement: Message `ZWEL0021I` includes the version of launcher ([#???][https://github.com/zowe/launcher/pull/???])
+- Enhancement: Message `ZWEL0021I` includes the version of launcher ([#167][https://github.com/zowe/launcher/pull/167])
 
 ## 3.3.0
 - Bugfix: `zowe.sysMessages` feature was ignoring messages where the matching string was after the position of 126 ([#157](https://github.com/zowe/launcher/pull/157))

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Copyright Contributors to the Zowe Project.
 <h1 align="center">Zowe Launcher</h1>
 
 The Zowe launcher is a part of the Zowe server architecture that was added as an optional program for HA/FT usage in v1.
-In v2, the Zowe laucher became the sole way to start the Zowe servers.
+In v2, the Zowe launcher became the sole way to start the Zowe servers.
 The launcher's purpose is to start, restart, and stop each Zowe server component which has a `start` command,
 and in doing so it watches over such components for health (restarting them if they crash) and log management.
 
@@ -25,12 +25,20 @@ and in doing so it watches over such components for health (restarting them if t
 
 ## Building
 
-```
+The Zowe launcher is build with a version defined in [manifest.yaml](./manifest.yaml). This version is used in `ZWEL0021I` message.
+
+```shell
 cd zowe-launcher/build
 ./build.sh
 ```
 
-The launcher binary will be saved into the bin directory.
+For development purposes, it is possible to specify custom defined version, which must be compound from three numeric values and dots: for example `1.2.3`. Invalid version will be used as `0.0.0`.
+```shell
+cd zowe-launcher/build
+export LAUNCHER_VERSION=1.2.3 && ./build.sh
+```
+
+The launcher binary will be saved into the `bin` directory.
 
 ## Testing
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -3,9 +3,9 @@
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies
 # this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
-# 
+#
 # Copyright Contributors to the Zowe Project.
 
 WORKING_DIR=$(cd $(dirname "$0") && pwd)
@@ -18,7 +18,7 @@ WORKING_DIR=$(cd $(dirname "$0") && pwd)
 echo "********************************************************************************"
 echo "Building $PROJECT..."
 
-LAUNCHER="$WORKING_DIR/.."
+LAUNCHER_DIR="$WORKING_DIR/.."
 
 # Checks for and possibly downloads dependencies from env vars from above file
 . $WORKING_DIR/dependencies.sh
@@ -34,25 +34,22 @@ TMP_DIR="${WORKING_DIR}/tmp-${date_stamp}"
 
 mkdir -p "${TMP_DIR}" && cd "${TMP_DIR}"
 
-
-# Split version into parts
+# Split LIBYAML version into parts
 OLDIFS=$IFS
 IFS="."
-for part in ${VERSION}; do
-  if [ -z "$MAJOR" ]; then
-    MAJOR=$part
-  elif [ -z "$MINOR" ]; then
-    MINOR=$part
+for part in ${LIBYAML_BRANCH}; do
+  if [ -z "$LIBYAML_MAJOR" ]; then
+    LIBYAML_MAJOR=$part
+  elif [ -z "$LIBYAML_MINOR" ]; then
+    LIBYAML_MINOR=$part
   else
-    PATCH=$part
+    LIBYAML_PATCH=$part
   fi
 done
 IFS=$OLDIFS
 
-VERSION="\"${VERSION}\""
-
-rm -f "${LAUNCHER}/bin/zowe_launcher"
-mkdir -p "${LAUNCHER}/bin"
+rm -f "${LAUNCHER_DIR}/bin/zowe_launcher"
+mkdir -p "${LAUNCHER_DIR}/bin"
 
 GSKDIR=/usr/lpp/gskssl
 GSKINC="${GSKDIR}/include"
@@ -64,10 +61,10 @@ xlclang \
   -q64 \
   -qascii \
   "-Wc,float(ieee),longname,langlvl(extc99),gonum,goff,ASM,asmlib('CEE.SCEEMAC','SYS1.MACLIB','SYS1.MODGEN')" \
-  -DYAML_VERSION_MAJOR=${MAJOR} \
-  -DYAML_VERSION_MINOR=${MINOR} \
-  -DYAML_VERSION_PATCH=${PATCH} \
-  -DYAML_VERSION_STRING="${VERSION}" \
+  -DYAML_VERSION_MAJOR=${LIBYAML_MAJOR} \
+  -DYAML_VERSION_MINOR=${LIBYAML_MINOR} \
+  -DYAML_VERSION_PATCH=${LIBYAML_PATCH} \
+  -DYAML_VERSION_STRING="\"${LIBYAML_BRANCH}\"" \
   -DYAML_DECLARE_STATIC=1 \
   -D_OPEN_SYS_FILE_EXT=1 \
   -D_XOPEN_SOURCE=600 \
@@ -95,7 +92,20 @@ if [ $rc -ne 0 ]; then
   exit 8
 fi
 
-echo "Compiling zowe_launcher ${MAJOR}.${MINOR}.${PATCH}+${launcher_date_stamp}"
+# LAUNCHER_VERSION can be exported to specific version
+# However C code is expecting numbers
+# print $1/1 -> numeric input => numeric output, other input => "0"
+if [ -z "${LAUNCHER_VERSION}" ]; then
+  LAUNCHER_VERSION=$(cat "${LAUNCHER_DIR}/manifest.yaml" | grep -e "^version:" | awk -F: '{ print $2 }')
+  LAUNCHER_VERSION=$(echo "${LAUNCHER_VERSION}" | awk '{$1=$1};1')  # awk = strip leading and trailing spaces
+fi
+if [ -n "${LAUNCHER_VERSION}" ]; then
+  LAUNCHER_MAJOR=$(echo "${LAUNCHER_VERSION}" | awk -F. '{ print $1/1 }')
+  LAUNCHER_MINOR=$(echo "${LAUNCHER_VERSION}" | awk -F. '{ print $2/1 }')
+  LAUNCHER_PATCH=$(echo "${LAUNCHER_VERSION}" | awk -F. '{ print $3/1 }')
+fi
+
+echo "Compiling zowe_launcher ${LAUNCHER_MAJOR}.${LAUNCHER_MINOR}.${LAUNCHER_PATCH}+${launcher_date_stamp}"
 
 xlclang \
   -q64 \
@@ -108,17 +118,17 @@ xlclang \
   -DNOIBMHTTP=1 \
   -DNEW_CAA_LOCATIONS=1 \
   -DUSE_ZOWE_TLS=1 \
-  -DPRODUCT_MAJOR_VERSION="${MAJOR}" \
-  -DPRODUCT_MINOR_VERSION="${MINOR}" \
-  -DPRODUCT_REVISION="${PATCH}" \
-  -DPRODUCT_VERSION_DATE_STAMP="${launcher_date_stamp}" \
-  -I "${LAUNCHER}/src/msg.h" \
+  -DLAUNCHER_VERSION_MAJOR="${LAUNCHER_MAJOR}" \
+  -DLAUNCHER_VERSION_MINOR="${LAUNCHER_MINOR}" \
+  -DLAUNCHER_VERSION_PATCH="${LAUNCHER_PATCH}" \
+  -DLAUNCHER_VERSION_DATE_STAMP="${launcher_date_stamp}" \
+  -I "${LAUNCHER_DIR}/src/msg.h" \
   -I "${DEPS_DESTINATION}/${COMMON}/h" \
   -I "${DEPS_DESTINATION}/${COMMON}/platform/posix" \
   -I ${GSKINC} \
   -I "${DEPS_DESTINATION}/${LIBYAML}/include" \
   -I "${DEPS_DESTINATION}/${QUICKJS}" \
-  -o "${LAUNCHER}/bin/zowe_launcher" \
+  -o "${LAUNCHER_DIR}/bin/zowe_launcher" \
   api.o \
   reader.o \
   scanner.o \
@@ -133,7 +143,7 @@ xlclang \
   libunicode.o \
   libregexp.o \
   polyfill.o \
-  ${LAUNCHER}/src/main.c \
+  ${LAUNCHER_DIR}/src/main.c \
   ${DEPS_DESTINATION}/${COMMON}/c/alloc.c \
   ${DEPS_DESTINATION}/${COMMON}/c/bpxskt.c \
   ${DEPS_DESTINATION}/${COMMON}/c/charsets.c \
@@ -179,7 +189,7 @@ fi
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies
 # this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
-# 
+#
 # Copyright Contributors to the Zowe Project.

--- a/build/build.sh
+++ b/build/build.sh
@@ -28,6 +28,7 @@ DEPS_DESTINATION=$(get_destination "${WORKING_DIR}/.." "${PROJECT}")
 # These paths assume that the build is run from /launcher/builds
 
 date_stamp=$(date +%Y%m%d%S)
+launcher_date_stamp=$(date +%Y%m%d)
 
 TMP_DIR="${WORKING_DIR}/tmp-${date_stamp}"
 
@@ -56,7 +57,7 @@ mkdir -p "${LAUNCHER}/bin"
 GSKDIR=/usr/lpp/gskssl
 GSKINC="${GSKDIR}/include"
 
-echo "Compiling qascii libyaml and quickjs"
+echo "Compiling qascii libyaml \"${LIBYAML_BRANCH}\" and quickjs \"${QUICKJS_BRANCH}\""
 
 xlclang \
   -c \
@@ -94,7 +95,7 @@ if [ $rc -ne 0 ]; then
   exit 8
 fi
 
-echo "Compiling zowe_launcher"
+echo "Compiling zowe_launcher ${MAJOR}.${MINOR}.${PATCH}+${launcher_date_stamp}"
 
 xlclang \
   -q64 \
@@ -107,6 +108,10 @@ xlclang \
   -DNOIBMHTTP=1 \
   -DNEW_CAA_LOCATIONS=1 \
   -DUSE_ZOWE_TLS=1 \
+  -DPRODUCT_MAJOR_VERSION="${MAJOR}" \
+  -DPRODUCT_MINOR_VERSION="${MINOR}" \
+  -DPRODUCT_REVISION="${PATCH}" \
+  -DPRODUCT_VERSION_DATE_STAMP="${launcher_date_stamp}" \
   -I "${LAUNCHER}/src/msg.h" \
   -I "${DEPS_DESTINATION}/${COMMON}/h" \
   -I "${DEPS_DESTINATION}/${COMMON}/platform/posix" \

--- a/build/launcher.proj.env
+++ b/build/launcher.proj.env
@@ -1,5 +1,5 @@
 PROJECT="launcher"
-VERSION=3.3.0
+# VERSION= used from manifest.yaml
 DEPS="QUICKJS LIBYAML COMMON"
 
 QUICKJS="quickjs"

--- a/src/main.c
+++ b/src/main.c
@@ -76,6 +76,20 @@ extern char ** environ;
 
 #define YAML_ERROR_MAX 1024
 
+#ifndef PRODUCT_MAJOR_VERSION
+#define PRODUCT_MAJOR_VERSION 0
+#endif
+#ifndef PRODUCT_MINOR_VERSION
+#define PRODUCT_MINOR_VERSION 0
+#endif
+#ifndef PRODUCT_REVISION
+#define PRODUCT_REVISION 0
+#endif
+#ifndef PRODUCT_VERSION_DATE_STAMP
+#define PRODUCT_VERSION_DATE_STAMP 0
+#endif
+char launcherVersion[40];
+
 // Progressive restart internals in seconds
 static int restart_intervals_default[] = {1, 1, 1, 5, 5, 10, 20, 60, 120, 240};
 
@@ -1908,9 +1922,10 @@ int main(int argc, char **argv) {
   }
 
   setenv("_BPXK_AUTOCVT", "ON", 1);
-  INFO(MSG_LAUNCHER_START);
+  sprintf(launcherVersion, "%d.%d.%d+%d", PRODUCT_MAJOR_VERSION, PRODUCT_MINOR_VERSION, PRODUCT_REVISION, PRODUCT_VERSION_DATE_STAMP);
+  INFO(MSG_LAUNCHER_START, launcherVersion);
   INFO(MSG_LINE_LENGTH);
-  printf_wto(MSG_LAUNCHER_START); // Manual sys log print (messages not set here yet)
+  printf_wto(MSG_LAUNCHER_START, launcherVersion); // Manual sys log print (messages not set here yet)
 
   zl_config_t config = read_config(argc, argv);
   zl_context.config = config;

--- a/src/main.c
+++ b/src/main.c
@@ -76,17 +76,17 @@ extern char ** environ;
 
 #define YAML_ERROR_MAX 1024
 
-#ifndef PRODUCT_MAJOR_VERSION
-#define PRODUCT_MAJOR_VERSION 0
+#ifndef LAUNCHER_VERSION_MAJOR
+#define LAUNCHER_VERSION_MAJOR 0
 #endif
-#ifndef PRODUCT_MINOR_VERSION
-#define PRODUCT_MINOR_VERSION 0
+#ifndef LAUNCHER_VERSION_MINOR
+#define LAUNCHER_VERSION_MINOR 0
 #endif
-#ifndef PRODUCT_REVISION
-#define PRODUCT_REVISION 0
+#ifndef LAUNCHER_VERSION_PATCH
+#define LAUNCHER_VERSION_PATCH 0
 #endif
-#ifndef PRODUCT_VERSION_DATE_STAMP
-#define PRODUCT_VERSION_DATE_STAMP 0
+#ifndef LAUNCHER_VERSION_DATE_STAMP
+#define LAUCHNER_VERSION_DATE_STAMP 0
 #endif
 char launcherVersion[40];
 
@@ -1922,7 +1922,7 @@ int main(int argc, char **argv) {
   }
 
   setenv("_BPXK_AUTOCVT", "ON", 1);
-  sprintf(launcherVersion, "%d.%d.%d+%d", PRODUCT_MAJOR_VERSION, PRODUCT_MINOR_VERSION, PRODUCT_REVISION, PRODUCT_VERSION_DATE_STAMP);
+  sprintf(launcherVersion, "%d.%d.%d+%d", LAUNCHER_VERSION_MAJOR, LAUNCHER_VERSION_MINOR, LAUNCHER_VERSION_PATCH, LAUNCHER_VERSION_DATE_STAMP);
   INFO(MSG_LAUNCHER_START, launcherVersion);
   INFO(MSG_LINE_LENGTH);
   printf_wto(MSG_LAUNCHER_START, launcherVersion); // Manual sys log print (messages not set here yet)

--- a/src/msg.h
+++ b/src/msg.h
@@ -33,7 +33,7 @@
 #define MSG_INST_PREPARED       MSG_PREFIX "0018I" " Zowe instance prepared successfully\n"
 #define MSG_LAUNCHER_STOPING    MSG_PREFIX "0019I" " Zowe Launcher stopping\n"
 #define MSG_LOADING_YAML        MSG_PREFIX "0020I" " loading '%s'\n"
-#define MSG_LAUNCHER_START      MSG_PREFIX "0021I" " Zowe Launcher starting %s\n"
+#define MSG_LAUNCHER_START      MSG_PREFIX "0021I" " Zowe Launcher starting, version is %s\n"
 #define MSG_LAUNCHER_STOPPED    MSG_PREFIX "0022I" " Zowe Launcher stopped\n"
 #define MSG_YAML_FILE           MSG_PREFIX "0023I" " Zowe YAML config file is \'%s\'\n"
 #define MSG_HA_INST_ID          MSG_PREFIX "0024I" " HA_INSTANCE_ID is '%s'\n"

--- a/src/msg.h
+++ b/src/msg.h
@@ -33,7 +33,7 @@
 #define MSG_INST_PREPARED       MSG_PREFIX "0018I" " Zowe instance prepared successfully\n"
 #define MSG_LAUNCHER_STOPING    MSG_PREFIX "0019I" " Zowe Launcher stopping\n"
 #define MSG_LOADING_YAML        MSG_PREFIX "0020I" " loading '%s'\n"
-#define MSG_LAUNCHER_START      MSG_PREFIX "0021I" " Zowe Launcher starting\n"
+#define MSG_LAUNCHER_START      MSG_PREFIX "0021I" " Zowe Launcher starting %s\n"
 #define MSG_LAUNCHER_STOPPED    MSG_PREFIX "0022I" " Zowe Launcher stopped\n"
 #define MSG_YAML_FILE           MSG_PREFIX "0023I" " Zowe YAML config file is \'%s\'\n"
 #define MSG_HA_INST_ID          MSG_PREFIX "0024I" " HA_INSTANCE_ID is '%s'\n"

--- a/test/config-syntax.sh
+++ b/test/config-syntax.sh
@@ -14,14 +14,19 @@
 print=
 errors=0
 
-# Get the launchers's version
-. ../build/launcher.proj.env
+# Get the launchers's version from manifest.yaml
+VERSION=$(cat "../manifest.yaml" | grep -e "^version:" | awk -F: '{ print $2 }' | awk '{$1=$1};1')
 
 if [ ! -z "${1}" ]; then
     print='1'
 fi
 
 LAUNCHER='../bin/zowe_launcher'
+if [ ! -f "${LAUNCHER}" ]; then
+    echo "Executable for Zowe launcher not found at: ${LAUNCHER}"
+    exit 255
+fi
+
 ABS_PATH=$(cd .; pwd)
 
 TEST_FILES='./files'

--- a/test/config-syntax.sh
+++ b/test/config-syntax.sh
@@ -14,6 +14,9 @@
 print=
 errors=0
 
+# Get the launchers's version
+. ../build/launcher.proj.env
+
 if [ ! -z "${1}" ]; then
     print='1'
 fi
@@ -77,8 +80,8 @@ done <<EOF
 CONFIG | HA-INSTANCE | TEXT-TO-FIND | DESCRIPTION | ZLDEBUG
  | | PANIC! readJson got null pathElement | No config leads to PANIC!
 FILE(${ZOWE_EMPTY}) | | ZWEL0318E - failed to get root node in YAML | Empty config leads to ZWEL0318E
-${ABS_ZOWE} | | ZWEL0021I Zowe Launcher starting | Check the basic message ZWEL0021I
-${ZOWE} | | INFO ZWEL0023I Zowe YAML config file is 'FILE(${ZOWE})' | ZWEL0023I wrapped by FILE()
+${ABS_ZOWE} | | ZWEL0021I Zowe Launcher starting, version is ${VERSION}+ | Check the basic message ZWEL0021I
+${ZOWE} | | INFO ZWEL0023I Zowe YAML config file is '${ZOWE}' | ZWEL0023I
 FILE(${ZOWE}) | | INFO ZWEL0023I Zowe YAML config file is 'FILE(${ZOWE})' | Same as previous test
 ${ABS_ZOWE} | | INFO ZWEL0023I Zowe YAML config file is 'FILE(${ABS_ZOWE})' | ZWEL0023I wrapped by FILE()
 ${ABS_ZOWE2} | | INFO ZWEL0023I Zowe YAML config file is 'FILE(${ABS_ZOWE2})' | Should be able to read the file


### PR DESCRIPTION
Fixes #82

## Changes
### Version in `ZWEL0021I`
* Before: `ZWEL0021I Zowe Launcher starting`
* Now: `ZWEL0021I Zowe Launcher starting, version is 3.4.0+20250916`

### `build.sh`
* Launcher version is taken from `manifest.yaml`
* Launcher version can be user defined, for example by `export LAUNCHER_VERSION=4.5.6`
* `libyaml` is using branch for version
#### More info when buiding
`libyaml`, `quickjs` branch and `zowe_launcher` version:
```
Compiling qascii libyaml "0.2.5" and quickjs "main"
Compiling zowe_launcher 3.4.0+20250918
```

### README
* Building update

### Test
#### `SYSPRINT`
```
2025-09-18 08:29:03.117 <ZWELNCH:17106915> ZWESVUSR INFO ZWEL0021I Zowe Launcher starting, version is 3.4.0+20250918
```

#### `SYSLOG`
```
04:29:03.11 STC80292 00000094  +ZWEL0021I Zowe Launcher starting, version is 3.4.0+20250918
```