### PR TITLE
Escape `\` in environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to the Zowe Launcher package will be documented in this file
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.4.0
-- Bugfix: Escape backslash when used in environment variable ([#168]https://github.com/zowe/launcher/pull/168)
+- Bugfix: Escape backslash when used in environment variable ([#168](https://github.com/zowe/launcher/pull/168))
 
 ## 3.3.0
-- Bugfix: `zowe.sysMessages` feature was ignoring messages where the matching string was after the position of 126 ([#157]https://github.com/zowe/launcher/pull/157)
+- Bugfix: `zowe.sysMessages` feature was ignoring messages where the matching string was after the position of 126 ([#157](https://github.com/zowe/launcher/pull/157))
 - Enhancement: Launcher can now accept PARMLIB CONFIG entries that have more than one member name ([#146](https://github.com/zowe/launcher/pull/146))
 - Enhancement: Trimming the sys messages to print from the sys-message-id as optional based on the zowe.sysMessageTrim=true/false. (#147)
 - Enhancement: Avoid starting individual apiml components when apiml modulith is enabled ([#160](https://github.com/zowe/launcher/pull/160))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,16 @@
 All notable changes to the Zowe Launcher package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
-## 3.3
+## 3.4.0
+- Bugfix: Escape backslash when used in environment variable ([#1??]https://github.com/zowe/launcher/pull/1??)
+
+## 3.3.0
 - Bugfix: `zowe.sysMessages` feature was ignoring messages where the matching string was after the position of 126 ([#157]https://github.com/zowe/launcher/pull/157)
 - Enhancement: Launcher can now accept PARMLIB CONFIG entries that have more than one member name ([#146](https://github.com/zowe/launcher/pull/146))
 - Enhancement: Trimming the sys messages to print from the sys-message-id as optional based on the zowe.sysMessageTrim=true/false. (#147)
 - Enhancement: Avoid starting individual apiml components when apiml modulith is enabled ([#160](https://github.com/zowe/launcher/pull/160))
 
-## 3.1
+## 3.1.0
 - Bugfix: HEAPPOOLS and HEAPPOOLS64 no longer need to be set to OFF for launcher (#133)
 
 ## 2.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 All notable changes to the Zowe Launcher package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
-## 3.5.0
-- Bugfix: Escape backslash when used in environment variable ([#168](https://github.com/zowe/launcher/pull/168))
+## 3.6.0
+- Bugfix: Escape backslash, backtick and dollar sign when used in environment variable ([#168](https://github.com/zowe/launcher/pull/168))
 
 ## 3.4.0
 - Enhancement: Message `ZWEL0021I` includes the version of launcher ([#167](https://github.com/zowe/launcher/pull/167))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe Launcher package will be documented in this file
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.4.0
-- Bugfix: Escape backslash when used in environment variable ([#1??]https://github.com/zowe/launcher/pull/1??)
+- Bugfix: Escape backslash when used in environment variable ([#168]https://github.com/zowe/launcher/pull/168)
 
 ## 3.3.0
 - Bugfix: `zowe.sysMessages` feature was ignoring messages where the matching string was after the position of 126 ([#157]https://github.com/zowe/launcher/pull/157)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 All notable changes to the Zowe Launcher package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
-## 3.4.0
+## 3.5.0
 - Bugfix: Escape backslash when used in environment variable ([#168](https://github.com/zowe/launcher/pull/168))
+
+## 3.4.0
+- Enhancement: Message `ZWEL0021I` includes the version of launcher ([#167](https://github.com/zowe/launcher/pull/167))
 
 ## 3.3.0
 - Bugfix: `zowe.sysMessages` feature was ignoring messages where the matching string was after the position of 126 ([#157](https://github.com/zowe/launcher/pull/157))

--- a/src/main.c
+++ b/src/main.c
@@ -468,7 +468,7 @@ static char* jsonToString(Json *json) {
       return jsonAsBoolean(json) ? "true" : "false";
     case JSON_TYPE_NUMBER:
     case JSON_TYPE_INT64:
-      output = malloc(21); // Longest string possible -9223372036854775807
+      output = malloc(21); // Longest string possible -9223372036854775808 (20+\0)
       snprintf(output, 21, "%ld", jsonAsInt64(json));
       return output;
     case JSON_TYPE_DOUBLE:

--- a/src/main.c
+++ b/src/main.c
@@ -453,27 +453,18 @@ static bool arrayListContains(ArrayList *list, char *element) {
 
 static char* escape_string(char *input) {
     int length = strlen(input);
-    int quotes = 0;
-    int backSlashes = 0;
-    for (int i = 0; i < length; i++) {
-        if (input[i] == '\"') quotes++;
-        if (input[i] == '\\') backSlashes++;
-    }
-
-    // 2 + 1 = add quote on first and the last position and \0 at the end
-    // quotes & backSlashes = add '\' to escape '"' and '\'
-    char *output = malloc(length + quotes + backSlashes + 2 + 1);
+    // Worst case: every character needs escaping
+    char *output = malloc(length * 2 + 2 + 1);
     output[0] = '\"';
     int j = 1;
     for (int i = 0; i < length; i++) {
-        if (input[i] == '\"' || input[i] == '\\') {
+        if (input[i] == '\"' || input[i] == '\\' || input[i] == '$' || input[i] == '`') {
             output[j++] = '\\';
         }
         output[j++] = input[i];
     }
     output[j++] = '\"';
     output[j++] = 0;
-
     return output;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -481,8 +481,9 @@ static char* jsonToString(Json *json) {
 }
 
 // Zowe.environments key must follow Unix variable name syntax:
-// alphaNum | underscore & first char is not a digit
-static bool is_key_valid_unix_name(char *key) {
+// * The first char must not be a digit
+// * Any characters must be either alphanumeric or an underscore
+static bool is_key_valid_unix_name(const char *key) {
     int length = strlen(key);
     if (!length) {
         return false;

--- a/src/main.c
+++ b/src/main.c
@@ -436,15 +436,19 @@ static bool arrayListContains(ArrayList *list, char *element) {
 static char* escape_string(char *input) {
     int length = strlen(input);
     int quotes = 0;
+    int backSlashes = 0;
     for (int i = 0; i < length; i++) {
         if (input[i] == '\"') quotes++;
+        if (input[i] == '\\') backSlashes++;
     }
 
-    char *output = malloc(length + quotes + 2 + 1); // add quote on first and the last position and escape quotes inside
+    // 2 + 1 = add quote on first and the last position and \0 at the end
+    // quotes & backSlashes = add '\' to escape '"' and '\'
+    char *output = malloc(length + quotes + backSlashes + 2 + 1);
     output[0] = '\"';
     int j = 1;
     for (int i = 0; i < length; i++) {
-        if (input[i] == '\"') {
+        if (input[i] == '\"' || input[i] == '\\') {
             output[j++] = '\\';
         }
         output[j++] = input[i];

--- a/src/main.c
+++ b/src/main.c
@@ -480,11 +480,19 @@ static char* jsonToString(Json *json) {
   }
 }
 
-static bool is_valid_key(char *key) {
+// Zowe.environments key must follow Unix variable name syntax:
+// alphaNum | underscore & first char is not a digit
+static bool is_key_valid_unix_name(char *key) {
     int length = strlen(key);
+    if (!length) {
+        return false;
+    }
+    if (isdigit(key[0])) {
+        return false;
+    }
     for (int i = 0; i < length; i++) {
         if (isalnum(key[i])) continue;
-        if (strchr("_-", key[i])) continue;
+        if (key[i] == '_') continue;
         return false;
     }
     return true;
@@ -540,8 +548,8 @@ static void set_shared_uss_env(ConfigManager *configmgr) {
     // Get all environment variables defined in zowe.yaml and put them in the output as they are
     for (JsonProperty *property = jsonObjectGetFirstProperty(object); property != NULL; property = jsonObjectGetNextProperty(property)) {
       char *key = jsonPropertyGetKey(property);
-      if (!is_valid_key(key)) {
-        WARN("Key in zowe.yaml `zowe.environments.%s` is invalid and it will be ignored\n", key);
+      if (!is_key_valid_unix_name(key)) {
+        WARN("Key in configuration `zowe.environments.%s` is invalid and it will be ignored\n", key);
         continue;
       }
 

--- a/test/README.md
+++ b/test/README.md
@@ -14,3 +14,7 @@ Copyright Contributors to the Zowe Project.
 
 Simple shell script to test basic functionality, such as treating items in environment variable `CONFIG`, `haInstace` and typical start-up messages.
 Return code is the number detected errors. To see an output, use any parameter, for example `./config-syntax.sh print`.
+
+## Environments
+
+Script for testing `zowe.environments`, especially escaping strings with `\` or `"`. See [config](./files/zowe.environments.yaml) used for testing. It will only print filtered output of Launcher and configuration.

--- a/test/README.md
+++ b/test/README.md
@@ -17,4 +17,8 @@ Return code is the number detected errors. To see an output, use any parameter, 
 
 ## Environments
 
-Script for testing `zowe.environments`, especially escaping strings with `\` or `"`. See [config](./files/zowe.environments.yaml) used for testing. It will only print filtered output of Launcher and configuration.
+Script for testing `zowe.environments`:
+* Escaping strings with `\` or `"`. It will only print filtered output of Launcher and configuration.
+* Ignoring environment variables, which are not valid unix names.
+
+See [config](./files/zowe.environments.yaml) used for testing.

--- a/test/README.md
+++ b/test/README.md
@@ -18,7 +18,8 @@ Return code is the number detected errors. To see an output, use any parameter, 
 ## Environments
 
 Script for testing `zowe.environments`:
-* Escaping strings with `\` or `"`. It will only print filtered output of Launcher and configuration.
+* Escaping strings with `\` or `"`. It checks only if the variable is in output.
 * Ignoring environment variables, which are not valid unix names.
+* Return code is the number detected errors.
 
 See [config](./files/zowe.environments.yaml) used for testing.

--- a/test/config-syntax.sh
+++ b/test/config-syntax.sh
@@ -19,6 +19,11 @@ if [ ! -z "${1}" ]; then
 fi
 
 LAUNCHER='../bin/zowe_launcher'
+if [ ! -f "{LAUNCHER}" ]; then
+    echo "Executable \"${LAUNCHER}\" not found."
+    exit 1
+fi
+
 ABS_PATH=$(cd .; pwd)
 
 TEST_FILES='./files'

--- a/test/config-syntax.sh
+++ b/test/config-syntax.sh
@@ -21,7 +21,7 @@ fi
 LAUNCHER='../bin/zowe_launcher'
 if [ ! -f "${LAUNCHER}" ]; then
     echo "Executable \"${LAUNCHER}\" not found."
-    exit 1
+    exit 255
 fi
 
 ABS_PATH=$(cd .; pwd)

--- a/test/config-syntax.sh
+++ b/test/config-syntax.sh
@@ -8,7 +8,7 @@
 #
 # Copyright Contributors to the Zowe Project.
 
-# Start with_any_paramter -> prints output (diff style)
+# Start with any parameter -> prints output (diff style)
 #   rc of this = number of errors found
 
 print=

--- a/test/config-syntax.sh
+++ b/test/config-syntax.sh
@@ -19,7 +19,7 @@ if [ ! -z "${1}" ]; then
 fi
 
 LAUNCHER='../bin/zowe_launcher'
-if [ ! -f "{LAUNCHER}" ]; then
+if [ ! -f "${LAUNCHER}" ]; then
     echo "Executable \"${LAUNCHER}\" not found."
     exit 1
 fi

--- a/test/environments.sh
+++ b/test/environments.sh
@@ -29,7 +29,7 @@ if [ ! -z "${print}" ]; then
     "${LAUNCHER}" "ha1"
 fi
 
-LAUNCHER_OUTPUT=$("${LAUNCHER}" "ha1" 2>&1 | grep 'DEBUG shared env pos1')
+LAUNCHER_OUTPUT=$("${LAUNCHER}" "ha1" 2>&1 | grep "DEBUG shared env pos.*TEST_VAR.*")
 
 printf "%s\n\n" "${LAUNCHER_OUTPUT}"
 

--- a/test/environments.sh
+++ b/test/environments.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+
+# ---------------------------------------------------
+# Start with any paramter -> prints Launcher's output
+# ---------------------------------------------------
+
+print=
+
+if [ ! -z "${1}" ]; then
+    print='1'
+fi
+
+LAUNCHER='../bin/zowe_launcher'
+ZOWE_YAML="./files/zowe.environments.yaml"
+
+LAUNCHER_OUTPUT=
+export ZLDEBUG='ON'
+export CONFIG="FILE(${ZOWE_YAML})"
+
+if [ ! -z "${print}" ]; then
+    "${LAUNCHER}" "ha1"
+fi
+
+LAUNCHER_OUTPUT=$("${LAUNCHER}" "ha1" 2>&1 | grep 'DEBUG shared env pos1')
+
+printf "%s\n\n" "${LAUNCHER_OUTPUT}"
+
+printf "${ZOWE_YAML} TEST_VAR*:\n"
+cat "${ZOWE_YAML}" | grep TEST_VAR
+
+exit 0

--- a/test/environments.sh
+++ b/test/environments.sh
@@ -8,9 +8,8 @@
 #
 # Copyright Contributors to the Zowe Project.
 
-# ---------------------------------------------------
 # Start with any parameter -> prints Launcher's output
-# ---------------------------------------------------
+#   rc of this = number of errors found for "WARN Key in configuration `zowe.environments.<key>` is invalid"
 
 print=
 errors=0

--- a/test/environments.sh
+++ b/test/environments.sh
@@ -9,7 +9,7 @@
 # Copyright Contributors to the Zowe Project.
 
 # Start with any parameter -> prints Launcher's output
-#   rc of this = number of errors found for "WARN Key in configuration `zowe.environments.<key>` is invalid"
+#   rc of this = number of errors found
 
 print=
 errors=0
@@ -38,23 +38,34 @@ if [ ! -z "${print}" ]; then
     printf "%s" "${LAUNCHER_OUTPUT}"
 fi
 
+printf "\n---zowe.environments.TEST_VAR_* expected to be used or ignored ---\n\n"
 # awk prints between TEST_VAR_START= and TEST_VAR_END=
 LAUNCHER_OUTPUT_TEST_VAR=$(printf "%s" "${LAUNCHER_OUTPUT}" | awk '/TEST_VAR_START=/{flag=1}/TEST_VAR_END=/{print; flag=0}flag')
-printf "%s\n\n" "${LAUNCHER_OUTPUT_TEST_VAR}"
-
-awk '/TEST_VAR_START/{flag=1}/TEST_VAR_END/{print; flag=0}flag' "${ZOWE_YAML}"
+while read -r line; do
+    if [ -n "$(echo "${line}" | grep 'TEST_VAR_')" ]; then
+        key=$(echo "${line}" | cut -d: -f1)
+        if [ -n "$(echo "${line}" | grep '#')" ]; then
+            output=$(echo "${LAUNCHER_OUTPUT_TEST_VAR}" | grep "${key}")
+            if [ -n "${output}" ]; then
+                printf "OK: %s\n" "${output}"
+            else
+                echo "Key '${key}' not found!"
+                errors=`expr $errors + 1`
+            fi
+            
+        fi
+    fi
+done < "${ZOWE_YAML}"
 
 printf "\n---zowe.environments.* expected to be ignored ---\n\n"
-
 LAUNCHER_OUTPUT_KEYS=$(printf "%s" "${LAUNCHER_OUTPUT}" | grep -e 'Key in configuration')
-
 while read -r line; do
     if [ -n "$(echo "${line}" | grep -e '<ignored>')" ]; then
         key="$(echo "${line}" | awk -F: '{ print $1}')"
         key="\`zowe.environments.${key}\`"
         matchKey="$(printf "%s" "${LAUNCHER_OUTPUT_KEYS}" | grep -e "${key}")"
         if [ -n "${matchKey}" ]; then
-            printf "Key '%s' found:\n  %s\n" "${key}" "${matchKey}"
+            printf "OK: Key '%s' found: %s\n" "${key}" "${matchKey}"
         else
             echo "Key '${key}' not found!"
             errors=`expr $errors + 1`

--- a/test/environments.sh
+++ b/test/environments.sh
@@ -9,7 +9,7 @@
 # Copyright Contributors to the Zowe Project.
 
 # ---------------------------------------------------
-# Start with any paramter -> prints Launcher's output
+# Start with any parameter -> prints Launcher's output
 # ---------------------------------------------------
 
 print=

--- a/test/environments.sh
+++ b/test/environments.sh
@@ -13,6 +13,7 @@
 # ---------------------------------------------------
 
 print=
+errors=0
 
 if [ ! -z "${1}" ]; then
     print='1'
@@ -27,17 +28,39 @@ fi
 ZOWE_YAML="./files/zowe.environments.yaml"
 
 LAUNCHER_OUTPUT=
+LAUNCHER_OUTPUT_TEST_VAR=
+LAUNCHER_OUTPUT_KEYS=
 export ZLDEBUG='ON'
 export CONFIG="FILE(${ZOWE_YAML})"
 
+LAUNCHER_OUTPUT=$("${LAUNCHER}" "ha1" 2>&1)
+
 if [ ! -z "${print}" ]; then
-    "${LAUNCHER}" "ha1"
+    printf "%s" "${LAUNCHER_OUTPUT}"
 fi
 
 # awk prints between TEST_VAR_START= and TEST_VAR_END=
-LAUNCHER_OUTPUT=$("${LAUNCHER}" "ha1" 2>&1 | awk '/TEST_VAR_START=/{flag=1}/TEST_VAR_END=/{print; flag=0}flag')
-printf "%s\n\n" "${LAUNCHER_OUTPUT}"
+LAUNCHER_OUTPUT_TEST_VAR=$(printf "%s" "${LAUNCHER_OUTPUT}" | awk '/TEST_VAR_START=/{flag=1}/TEST_VAR_END=/{print; flag=0}flag')
+printf "%s\n\n" "${LAUNCHER_OUTPUT_TEST_VAR}"
 
 awk '/TEST_VAR_START/{flag=1}/TEST_VAR_END/{print; flag=0}flag' "${ZOWE_YAML}"
 
-exit 0
+printf "\n---zowe.environments.* expected to be ignored ---\n\n"
+
+LAUNCHER_OUTPUT_KEYS=$(printf "%s" "${LAUNCHER_OUTPUT}" | grep -e 'Key in configuration')
+
+while read -r line; do
+    if [ -n "$(echo "${line}" | grep -e '<ignored>')" ]; then
+        key="$(echo "${line}" | awk -F: '{ print $1}')"
+        key="\`zowe.environments.${key}\`"
+        matchKey="$(printf "%s" "${LAUNCHER_OUTPUT_KEYS}" | grep -e "${key}")"
+        if [ -n "${matchKey}" ]; then
+            printf "Key '%s' found:\n  %s\n" "${key}" "${matchKey}"
+        else
+            echo "Key '${key}' not found!"
+            errors=`expr $errors + 1`
+        fi
+    fi
+done < "${ZOWE_YAML}"
+
+exit $errors

--- a/test/environments.sh
+++ b/test/environments.sh
@@ -19,7 +19,7 @@ if [ ! -z "${1}" ]; then
 fi
 
 LAUNCHER='../bin/zowe_launcher'
-if [ ! -f "{LAUNCHER}" ]; then
+if [ ! -f "${LAUNCHER}" ]; then
     echo "Executable \"${LAUNCHER}\" not found."
     exit 1
 fi

--- a/test/environments.sh
+++ b/test/environments.sh
@@ -29,11 +29,10 @@ if [ ! -z "${print}" ]; then
     "${LAUNCHER}" "ha1"
 fi
 
-LAUNCHER_OUTPUT=$("${LAUNCHER}" "ha1" 2>&1 | grep "DEBUG shared env pos.*TEST_VAR.*")
-
+# awk prints between TEST_VAR_START= and TEST_VAR_END=
+LAUNCHER_OUTPUT=$("${LAUNCHER}" "ha1" 2>&1 | awk '/TEST_VAR_START=/{flag=1}/TEST_VAR_END=/{print; flag=0}flag')
 printf "%s\n\n" "${LAUNCHER_OUTPUT}"
 
-printf "${ZOWE_YAML} TEST_VAR*:\n"
-cat "${ZOWE_YAML}" | grep TEST_VAR
+awk '/TEST_VAR_START/{flag=1}/TEST_VAR_END/{print; flag=0}flag' "${ZOWE_YAML}"
 
 exit 0

--- a/test/environments.sh
+++ b/test/environments.sh
@@ -19,6 +19,11 @@ if [ ! -z "${1}" ]; then
 fi
 
 LAUNCHER='../bin/zowe_launcher'
+if [ ! -f "{LAUNCHER}" ]; then
+    echo "Executable \"${LAUNCHER}\" not found."
+    exit 1
+fi
+
 ZOWE_YAML="./files/zowe.environments.yaml"
 
 LAUNCHER_OUTPUT=

--- a/test/fakeRuntime/schemas/server-common.json
+++ b/test/fakeRuntime/schemas/server-common.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://zowe.org/schemas/v2/server-common",
+  "title": "Common types",
+  "description": "Simplified version for testing",
+  "$defs": {
+    "semverVersion": {
+      "$anchor": "zoweSemverVersion",
+      "type": "string",
+      "description": "A semantic version, see https://semver.org/",
+      "pattern": "^[0-9]*\\.[0-9]*\\.[0-9]*(-*[a-zA-Z][0-9a-zA-Z\\-\\.]*)?(\\+[0-9a-zA-Z\\-\\.]*)?$"
+    }
+  }
+}

--- a/test/fakeRuntime/schemas/zowe-yaml-schema.json
+++ b/test/fakeRuntime/schemas/zowe-yaml-schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://zowe.org/schemas/v2/server-base",
+  "title": "Zowe configuration file",
+  "description": "Simplified version for testing",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "zowe": {
+      "type": "object"
+    }
+  }
+}

--- a/test/files/zowe.environments.yaml
+++ b/test/files/zowe.environments.yaml
@@ -23,7 +23,7 @@ zowe:
       Rather in power than use; and keep thy friend
       Under thy own life's key: be check'd for silence,
       But never tax'd for speech.
-  TEST_VAR_END: \E\N\D              # "\\E\\N\\D"
+    TEST_VAR_END: \E\N\D            # "\\E\\N\\D"
   runtimeDirectory: "${{ () => {
         let thisPath = os.realpath('./fakeRuntime');
         if (thisPath[1] == 0) {

--- a/test/files/zowe.environments.yaml
+++ b/test/files/zowe.environments.yaml
@@ -29,7 +29,10 @@ zowe:
     TEST_VAR_STR_09: TE\"ST                     # "TE\\\"ST"
     TEST_VAR_STR_10: !!str 123                  # "123"
     TEST_VAR_STR_11: !!str true                 # "true"
-    TEST_VAR_STR_12: |-                         # William Shakespeare: All's Well That Ends Well
+    TEST_VAR_STR_12: "`cmd`"                    # "\`cmd\`"
+    TEST_VAR_STR_13: "$HOME"                    # "\$HOME"
+    TEST_VAR_STR_14: "$(ls -al)"                # "\$(ls -al)"
+    TEST_VAR_STR_15: |-
       Love all, trust a few,
       Do wrong to none: be able for thine enemy
       Rather in power than use; and keep thy friend

--- a/test/files/zowe.environments.yaml
+++ b/test/files/zowe.environments.yaml
@@ -1,5 +1,7 @@
 zowe:
   environments:
+    # For sipmlification, keep TEST_VAR_START as the first
+    # and TEST_VAR_END as the last variable
     TEST_VAR_START: \S\T\A\R\T      # "\\S\\T\\A\\R\\T"
     TEST_VAR01: 'TE\"ST'            # "TE\\\"ST"
     TEST_VAR02: "TE\"ST"            # "TE\"ST"

--- a/test/files/zowe.environments.yaml
+++ b/test/files/zowe.environments.yaml
@@ -58,7 +58,7 @@ zowe:
     ~null: not null                             # <ignored>
     =: equal sign                               # <ignored>
     <h1>: heading                               # <ignored>
-runtimeDirectory: "${{ () => {
+  runtimeDirectory: "${{ () => {
       let thisPath = os.realpath('./fakeRuntime');
       if (thisPath[1] == 0) {
         return thisPath[0];

--- a/test/files/zowe.environments.yaml
+++ b/test/files/zowe.environments.yaml
@@ -1,19 +1,29 @@
 zowe:
   environments:
-
-    TEST_VAR01: 'TE\"ST'        # "TE\\\"ST"
-    TEST_VAR02: "TE\"ST"        # "TE\"ST"
-    TEST_VAR03: TE\"ST          # "TE\\\"ST"
-    TEST_VAR04:                 #
-    TEST_VAR05: ~               #
-    TEST_VAR06: true            # true
-    TEST_VAR07: \\\\\\\\\\      # "\\\\\\\\\\\\\\\\\\\\"
-    TEST_VAR08: '""""""""""'    # "\"\"\"\"\"\"\"\"\"\""
-    TEST_VAR09: '"'             # "\""
-    TEST_VAR10: 123456          # 123456
-    TEST_VAR11: \n              # "\\n"
-    TEST_VAR12: \0              # "\\0"
-
+    TEST_VAR_START: \S\T\A\R\T      # "\\S\\T\\A\\R\\T"
+    TEST_VAR01: 'TE\"ST'            # "TE\\\"ST"
+    TEST_VAR02: "TE\"ST"            # "TE\"ST"
+    TEST_VAR03: TE\"ST              # "TE\\\"ST"
+    TEST_VAR04:                     #
+    TEST_VAR05: ~                   #
+    TEST_VAR06: true                # true
+    TEST_VAR07: \\\\\\\\\\          # "\\\\\\\\\\\\\\\\\\\\"
+    TEST_VAR08: '""""""""""'        # "\"\"\"\"\"\"\"\"\"\""
+    TEST_VAR09: '"'                 # "\""
+    TEST_VAR10: 123456              # 123456
+    TEST_VAR11: \n                  # "\\n"
+    TEST_VAR12: \0                  # "\\0"
+    TEST_VAR13:                     # Array
+      - kiwi
+      - banana
+      - orange
+    TEST_VAR14: |-                  # William Shakespeare: All's Well That Ends Well
+      Love all, trust a few,
+      Do wrong to none: be able for thine enemy
+      Rather in power than use; and keep thy friend
+      Under thy own life's key: be check'd for silence,
+      But never tax'd for speech.
+  TEST_VAR_END: \E\N\D              # "\\E\\N\\D"
   runtimeDirectory: "${{ () => {
         let thisPath = os.realpath('./fakeRuntime');
         if (thisPath[1] == 0) {

--- a/test/files/zowe.environments.yaml
+++ b/test/files/zowe.environments.yaml
@@ -1,0 +1,24 @@
+zowe:
+  environments:
+
+    TEST_VAR01: 'TE\"ST'        # "TE\\\"ST"
+    TEST_VAR02: "TE\"ST"        # "TE\"ST"
+    TEST_VAR03: TE\"ST          # "TE\\\"ST"
+    TEST_VAR04:                 #
+    TEST_VAR05: ~               #
+    TEST_VAR06: true            # true
+    TEST_VAR07: \\\\\\\\\\      # "\\\\\\\\\\\\\\\\\\\\"
+    TEST_VAR08: '""""""""""'    # "\"\"\"\"\"\"\"\"\"\""
+    TEST_VAR09: '"'             # "\""
+    TEST_VAR10: 123456          # 123456
+    TEST_VAR11: \n              # "\\n"
+    TEST_VAR12: \0              # "\\0"
+
+  runtimeDirectory: "${{ () => {
+        let thisPath = os.realpath('./fakeRuntime');
+        if (thisPath[1] == 0) {
+          return thisPath[0];
+        }
+        return undefined;
+      } ()
+    }}"

--- a/test/files/zowe.environments.yaml
+++ b/test/files/zowe.environments.yaml
@@ -48,6 +48,17 @@ zowe:
     TEST_VAR_NESTED:
       enabled: true
       disabled: false
+    # *** Embedded JS ***
+    TEST_VAR_EJS_01: "${{ zowe.environments.TEST_VAR_INT_01 }}"   # zowe.environments.TEST_VAR_INT_01
+    TEST_VAR_EJS_02: "${{ 1+1*7 }}"             # 8
+    TEST_VAR_EJS_03: "${{ 'EJS' }}"             # "EJS"
+    TEST_VAR_EJS_04: "${{ `EJS` }}"             # "EJS"
+    TEST_VAR_EJS_05: "${{ \"EJS\" }}"           # "EJS"
+    TEST_VAR_EJS_06: "${{ `E` + 'J' + \"S\" }}" # "EJS"
+    TEST_VAR_EJS_07: "${{ `\\` }}"              # "\\"
+    TEST_VAR_EJS_08: "${{                    /* # true */
+       () => { if (1 == 1) return true } ();
+      }}"
     TEST_VAR_END: \E\N\D                        # "\\E\\N\\D"
     # *** Ignored keys ***
     -key-: ~                                    # <ignored>

--- a/test/files/zowe.environments.yaml
+++ b/test/files/zowe.environments.yaml
@@ -46,11 +46,23 @@ zowe:
       - orange
     TEST_VAR_ARRAY_02: ['A', 'B', 'C']          # Array
     TEST_VAR_END: \E\N\D                        # "\\E\\N\\D"
-  runtimeDirectory: "${{ () => {
-        let thisPath = os.realpath('./fakeRuntime');
-        if (thisPath[1] == 0) {
-          return thisPath[0];
-        }
-        return undefined;
-      } ()
-    }}"
+    # *** Ignored keys ***
+    -key-: ~                                    # <ignored>
+    ?key: '?'                                   # <ignored>
+    1+1: =2                                     # <ignored>
+    1-1: "=0"                                   # <ignored>
+    _!_: '!!!'                                  # <ignored>
+    1TEST: true                                 # <ignored>
+    3_141592: 6535                              # <ignored>
+    (): !!int 0                                 # <ignored>
+    ~null: not null                             # <ignored>
+    =: equal sign                               # <ignored>
+    <h1>: heading                               # <ignored>
+runtimeDirectory: "${{ () => {
+      let thisPath = os.realpath('./fakeRuntime');
+      if (thisPath[1] == 0) {
+        return thisPath[0];
+      }
+      return undefined;
+    } ()
+  }}"

--- a/test/files/zowe.environments.yaml
+++ b/test/files/zowe.environments.yaml
@@ -36,15 +36,18 @@ zowe:
       Under thy own life's key: be check'd for silence,
       But never tax'd for speech.
     # *** Null ***
-    TEST_VAR_NULL_01:                           #
-    TEST_VAR_NULL_02: ~                         #
-    TEST_VAR_NULL_03: null                      #
+    TEST_VAR_NULL_01:
+    TEST_VAR_NULL_02: ~
+    TEST_VAR_NULL_03: null
     # *** Array ***
-    TEST_VAR_ARRAY_01:                          # Array
+    TEST_VAR_ARRAY_01:
       - kiwi
       - banana
       - orange
-    TEST_VAR_ARRAY_02: ['A', 'B', 'C']          # Array
+    TEST_VAR_ARRAY_02: ['A', 'B', 'C']
+    TEST_VAR_NESTED:
+      enabled: true
+      disabled: false
     TEST_VAR_END: \E\N\D                        # "\\E\\N\\D"
     # *** Ignored keys ***
     -key-: ~                                    # <ignored>

--- a/test/files/zowe.environments.yaml
+++ b/test/files/zowe.environments.yaml
@@ -1,31 +1,51 @@
 zowe:
   environments:
-    # For sipmlification, keep TEST_VAR_START as the first
-    # and TEST_VAR_END as the last variable
-    TEST_VAR_START: \S\T\A\R\T      # "\\S\\T\\A\\R\\T"
-    TEST_VAR01: 'TE\"ST'            # "TE\\\"ST"
-    TEST_VAR02: "TE\"ST"            # "TE\"ST"
-    TEST_VAR03: TE\"ST              # "TE\\\"ST"
-    TEST_VAR04:                     #
-    TEST_VAR05: ~                   #
-    TEST_VAR06: true                # true
-    TEST_VAR07: \\\\\\\\\\          # "\\\\\\\\\\\\\\\\\\\\"
-    TEST_VAR08: '""""""""""'        # "\"\"\"\"\"\"\"\"\"\""
-    TEST_VAR09: '"'                 # "\""
-    TEST_VAR10: 123456              # 123456
-    TEST_VAR11: \n                  # "\\n"
-    TEST_VAR12: \0                  # "\\0"
-    TEST_VAR13:                     # Array
-      - kiwi
-      - banana
-      - orange
-    TEST_VAR14: |-                  # William Shakespeare: All's Well That Ends Well
+    TEST_VAR_START: \S\T\A\R\T                  # "\\S\\T\\A\\R\\T"
+    # *** Bool ***
+    TEST_VAR_BOOL_01: true                      # true
+    TEST_VAR_BOOL_02: false                     # false
+    TEST_VAR_BOOL_03: !!bool true               # true
+    TEST_VAR_BOOL_04: !!bool false              # false
+    # *** Int ***
+    TEST_VAR_INT_01: 123456                     # 123456
+    TEST_VAR_INT_02: !!int 123456               # 123456
+    TEST_VAR_INT_03: 0x7FFFFFFF                 # 2147483647
+    TEST_VAR_INT_04: 0x00000001                 # 1
+    TEST_VAR_INT_05: !!int 0x7FFFFFFF           # 2147483647
+    TEST_VAR_INT_06: !!int 0x00000001           # 1
+    TEST_VAR_INT_07: 9223372036854775807        # 9223372036854775807
+    TEST_VAR_INT_08: !!int 9223372036854775807  # 9223372036854775807
+    TEST_VAR_INT_09: -9223372036854775808       # -9223372036854775808
+    TEST_VAR_INT_10: !!int -9223372036854775808 # -9223372036854775808
+    # *** Str ***
+    TEST_VAR_STR_01: \\\\\\\\\\                 # "\\\\\\\\\\\\\\\\\\\\"
+    TEST_VAR_STR_02: !!str \\\\\\\\\\           # "\\\\\\\\\\\\\\\\\\\\"
+    TEST_VAR_STR_03: '""""""""""'               # "\"\"\"\"\"\"\"\"\"\""
+    TEST_VAR_STR_04: '"'                        # "\""
+    TEST_VAR_STR_05: \n                         # "\\n"
+    TEST_VAR_STR_06: \0                         # "\\0"
+    TEST_VAR_STR_07: 'TE\"ST'                   # "TE\\\"ST"
+    TEST_VAR_STR_08: "TE\"ST"                   # "TE\"ST"
+    TEST_VAR_STR_09: TE\"ST                     # "TE\\\"ST"
+    TEST_VAR_STR_10: !!str 123                  # "123"
+    TEST_VAR_STR_11: !!str true                 # "true"
+    TEST_VAR_STR_12: |-                         # William Shakespeare: All's Well That Ends Well
       Love all, trust a few,
       Do wrong to none: be able for thine enemy
       Rather in power than use; and keep thy friend
       Under thy own life's key: be check'd for silence,
       But never tax'd for speech.
-    TEST_VAR_END: \E\N\D            # "\\E\\N\\D"
+    # *** Null ***
+    TEST_VAR_NULL_01:                           #
+    TEST_VAR_NULL_02: ~                         #
+    TEST_VAR_NULL_03: null                      #
+    # *** Array ***
+    TEST_VAR_ARRAY_01:                          # Array
+      - kiwi
+      - banana
+      - orange
+    TEST_VAR_ARRAY_02: ['A', 'B', 'C']          # Array
+    TEST_VAR_END: \E\N\D                        # "\\E\\N\\D"
   runtimeDirectory: "${{ () => {
         let thisPath = os.realpath('./fakeRuntime');
         if (thisPath[1] == 0) {


### PR DESCRIPTION
## Changes
Fixes #76.

### Problem 1
You can define such string in YAML.
```yaml
zowe:
  environments:
    TEST1: TE\"ST    # 'T' + 'E' + '\' + '"' + 'S' + 'T' => "TE\\\"ST"
    TEST2: 123
```
When trying to run `internal start prepare`:
```shell
ZWE_zowe_runtimeDirectory="/zowe" ZWE_CLI_PARAMETER_HA_INSTANCE="ha1" TEST1="TE\\"ST" TEST2=123...
```

Because of incorrect escape, the variable `TEST1` will break the command, correct escaping is `"TE\\\"ST"`.

**Note:** Such example is good one, because the command fails and launcher ends. But if you chain couple of wrong variables, it could end by creating unexpected variable.

### Problem 2
You can define such environment variable in YAML. This variable should be ignored, otherwise launcher tries to set `1=1`.
```yaml
zowe:
  environments:
    1:1
```

### Problem 3
You can currently define a (dangerous) command:
```yaml
zowe:
  environments:
    CURRENTLY_ALLOWED: $(crashLpar --all)
```

#### Consequence (with fix)
```yaml
zowe:
  environments:
    JAVA_SOMETHING: "$JAVA_HOME/something"  # $JAVA_HOME is not expanded
```

### `escape_string` solving Problem 1

This function was escaping only `"`. Updated to escape `\`, `` ` `` and `$` too.

### `is_valid_key` solving Problem 2

* Function (used just once) renamed to reflect what is trying to detect
* It follows the syntax for unix variable name: "first char is not a digit & (any char is alphaNum | underscore)"

### `test/environments.sh`

* Added new test, however it is challenging to compare strings with escape sequences in unix... The tests only prints Launcher's output and `zowe.yaml`.
* Added test for ignoring non-unix variable names.

```diff

! ---zowe.environments.TEST_VAR_* expected to be used or ignored ---

  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 3 is TEST_VAR_START="\S\T\A\R\T"
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 4 is TEST_VAR_BOOL_01=true
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 5 is TEST_VAR_BOOL_02=false
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 6 is TEST_VAR_BOOL_03=true
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 7 is TEST_VAR_BOOL_04=false
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 8 is TEST_VAR_INT_01=123456
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 9 is TEST_VAR_INT_02=123456
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 10 is TEST_VAR_INT_03="0x7FFFFFFF"
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 11 is TEST_VAR_INT_04="0x00000001"
- Key 'TEST_VAR_INT_05' not found!
- Key 'TEST_VAR_INT_06' not found!
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 12 is TEST_VAR_INT_07=9223372036854775807
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 13 is TEST_VAR_INT_08=9223372036854775807
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 14 is TEST_VAR_INT_09="-9223372036854775808"
- Key 'TEST_VAR_INT_10' not found!
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 15 is TEST_VAR_STR_01="\\\\\\\\\\"
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 16 is TEST_VAR_STR_02="\\\\\\\\\\"
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 17 is TEST_VAR_STR_03="\"\"\"\"\"\"\"\"\"\""
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 18 is TEST_VAR_STR_04="\""
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 19 is TEST_VAR_STR_05="\n"
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 21 is TEST_VAR_STR_07="TE\\"ST"
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 22 is TEST_VAR_STR_08="TE\"ST"
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 23 is TEST_VAR_STR_09="TE\\"ST"
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 24 is TEST_VAR_STR_10=123
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 25 is TEST_VAR_STR_11=true
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 26 is TEST_VAR_STR_12="Love all, trust a few,
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 27 is TEST_VAR_EJS_01=123456
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 28 is TEST_VAR_EJS_02=8
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 29 is TEST_VAR_EJS_03="EJS"
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 30 is TEST_VAR_EJS_04="EJS"
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 31 is TEST_VAR_EJS_05="EJS"
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 32 is TEST_VAR_EJS_06="EJS"
- Key 'TEST_VAR_EJS_07' not found!
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 33 is TEST_VAR_EJS_08=true
  OK: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID DEBUG shared env pos 34 is TEST_VAR_END="\E\N\D"

! ---zowe.environments.* expected to be ignored ---

  OK: Key '`zowe.environments.-key-`' found: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID WARN Key in configuration `zowe.environments.-key-` is invalid and it will be ignored
  OK: Key '`zowe.environments.?key`' found: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID WARN Key in configuration `zowe.environments.?key` is invalid and it will be ignored
  OK: Key '`zowe.environments.1+1`' found: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID WARN Key in configuration `zowe.environments.1+1` is invalid and it will be ignored
  OK: Key '`zowe.environments.1-1`' found: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID WARN Key in configuration `zowe.environments.1-1` is invalid and it will be ignored
  OK: Key '`zowe.environments._!_`' found: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID WARN Key in configuration `zowe.environments._!_` is invalid and it will be ignored
  OK: Key '`zowe.environments.1TEST`' found: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID WARN Key in configuration `zowe.environments.1TEST` is invalid and it will be ignored
  OK: Key '`zowe.environments.3_141592`' found: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID WARN Key in configuration `zowe.environments.3_141592` is invalid and it will be ignored
  OK: Key '`zowe.environments.()`' found: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID WARN Key in configuration `zowe.environments.()` is invalid and it will be ignored
  OK: Key '`zowe.environments.~null`' found: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID WARN Key in configuration `zowe.environments.~null` is invalid and it will be ignored
  OK: Key '`zowe.environments.=`' found: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID WARN Key in configuration `zowe.environments.=` is invalid and it will be ignored
  OK: Key '`zowe.environments.<h1>`' found: 2025-09-30 09:34:57.940 <ZWELNCH:330366> USERID WARN Key in configuration `zowe.environments.<h1>` is invalid and it will be ignored
```

### `test/fakeRuntime`
This is needed for running new test. Schema files were updated to be small, it does not matter for this test.

### `test/files/zowe.environments.yaml`
* `TEST_VAR*` for testing Problem 1
* Section `# *** Ignored keys ***` for testing of Problem 2
* `zowe.runtimeDirectory` must be absolute path, resolved with `os.realpath`.
