### PR TITLE
V2: Escape `\` in environment variable 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zowe Launcher package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 2.18.4
+- Bugfix: Escape backslash when used in environment variable ([#169](https://github.com/zowe/launcher/pull/169))
+
 ## 2.18.1
 - Bugfix: HEAPPOOLS and HEAPPOOLS64 no longer need to be set to OFF for launcher (#132)
 

--- a/src/main.c
+++ b/src/main.c
@@ -447,11 +447,19 @@ static char* jsonToString(Json *json) {
   }
 }
 
-static bool is_valid_key(char *key) {
+// Zowe.environments key must follow Unix variable name syntax:
+// alphaNum | underscore & first char is not a digit
+static bool is_key_valid_unix_name(char *key) {
     int length = strlen(key);
+    if (!length) {
+        return false;
+    }
+    if (isdigit(key[0])) {
+        return false;
+    }
     for (int i = 0; i < length; i++) {
         if (isalnum(key[i])) continue;
-        if (strchr("_-", key[i])) continue;
+        if (key[i] == '_') continue;
         return false;
     }
     return true;
@@ -507,7 +515,7 @@ static void set_shared_uss_env(ConfigManager *configmgr) {
     // Get all environment variables defined in zowe.yaml and put them in the output as they are
     for (JsonProperty *property = jsonObjectGetFirstProperty(object); property != NULL; property = jsonObjectGetNextProperty(property)) {
       char *key = jsonPropertyGetKey(property);
-      if (!is_valid_key(key)) {
+      if (!is_key_valid_unix_name(key)) {
         WARN("Key in zowe.yaml `zowe.environments.%s` is invalid and it will be ignored\n", key);
         continue;
       }

--- a/src/main.c
+++ b/src/main.c
@@ -448,8 +448,9 @@ static char* jsonToString(Json *json) {
 }
 
 // Zowe.environments key must follow Unix variable name syntax:
-// alphaNum | underscore & first char is not a digit
-static bool is_key_valid_unix_name(char *key) {
+// * The first char must not be a digit
+// * Any characters must be either alphanumeric or an underscore
+static bool is_key_valid_unix_name(const char *key) {
     int length = strlen(key);
     if (!length) {
         return false;

--- a/src/main.c
+++ b/src/main.c
@@ -401,29 +401,20 @@ static bool arrayListContains(ArrayList *list, char *element) {
 }
 
 static char* escape_string(char *input) {
-    int length = strlen(input);
-    int quotes = 0;
-    int backSlashes = 0;
-    for (int i = 0; i < length; i++) {
-        if (input[i] == '\"') quotes++;
-        if (input[i] == '\\') backSlashes++;
+  int length = strlen(input);
+  // Worst case: every character needs escaping
+  char *output = malloc(length * 2 + 2 + 1);
+  output[0] = '\"';
+  int j = 1;
+  for (int i = 0; i < length; i++) {
+    if (input[i] == '\"' || input[i] == '\\' || input[i] == '$' || input[i] == '`') {
+      output[j++] = '\\';
     }
-
-    // 2 + 1 = add quote on first and the last position and \0 at the end
-    // quotes & backSlashes = add '\' to escape '"' and '\'
-    char *output = malloc(length + quotes + backSlashes + 2 + 1);
-    output[0] = '\"';
-    int j = 1;
-    for (int i = 0; i < length; i++) {
-        if (input[i] == '\"' || input[i] == '\\') {
-            output[j++] = '\\';
-        }
-        output[j++] = input[i];
-    }
-    output[j++] = '\"';
-    output[j++] = 0;
-
-    return output;
+    output[j++] = input[i];
+  }
+  output[j++] = '\"';
+  output[j++] = 0;
+  return output;
 }
 
 static char* jsonToString(Json *json) {
@@ -451,19 +442,19 @@ static char* jsonToString(Json *json) {
 // * The first char must not be a digit
 // * Any characters must be either alphanumeric or an underscore
 static bool is_key_valid_unix_name(const char *key) {
-    int length = strlen(key);
-    if (!length) {
-        return false;
-    }
-    if (isdigit(key[0])) {
-        return false;
-    }
-    for (int i = 0; i < length; i++) {
-        if (isalnum(key[i])) continue;
-        if (key[i] == '_') continue;
-        return false;
-    }
-    return true;
+  int length = strlen(key);
+  if (!length) {
+    return false;
+  }
+  if (isdigit(key[0])) {
+    return false;
+  }
+  for (int i = 0; i < length; i++) {
+    if (isalnum(key[i])) continue;
+    if (key[i] == '_') continue;
+    return false;
+  }
+  return true;
 }
 
 static void set_shared_uss_env(ConfigManager *configmgr) {

--- a/src/main.c
+++ b/src/main.c
@@ -403,15 +403,19 @@ static bool arrayListContains(ArrayList *list, char *element) {
 static char* escape_string(char *input) {
     int length = strlen(input);
     int quotes = 0;
+    int backSlashes = 0;
     for (int i = 0; i < length; i++) {
         if (input[i] == '\"') quotes++;
+        if (input[i] == '\\') backSlashes++;
     }
 
-    char *output = malloc(length + quotes + 2 + 1); // add quote on first and the last position and escape quotes inside
+    // 2 + 1 = add quote on first and the last position and \0 at the end
+    // quotes & backSlashes = add '\' to escape '"' and '\'
+    char *output = malloc(length + quotes + backSlashes + 2 + 1);
     output[0] = '\"';
     int j = 1;
     for (int i = 0; i < length; i++) {
-        if (input[i] == '\"') {
+        if (input[i] == '\"' || input[i] == '\\') {
             output[j++] = '\\';
         }
         output[j++] = input[i];
@@ -431,7 +435,7 @@ static char* jsonToString(Json *json) {
       return jsonAsBoolean(json) ? "true" : "false";
     case JSON_TYPE_NUMBER:
     case JSON_TYPE_INT64:
-      output = malloc(21); // Longest string possible -9223372036854775807
+      output = malloc(21); // Longest string possible -9223372036854775808
       snprintf(output, 21, "%ld", jsonAsInt64(json));
       return output;
     case JSON_TYPE_DOUBLE:


### PR DESCRIPTION
V2 of #168.

V3 test used for V2 code, getting the same result:

```
---zowe.environments.TEST_VAR_* expected to be used or ignored ---

OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 3 is TEST_VAR_START="\S\T\A\R\T"
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 4 is TEST_VAR_BOOL_01=true
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 5 is TEST_VAR_BOOL_02=false
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 6 is TEST_VAR_BOOL_03=true
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 7 is TEST_VAR_BOOL_04=false
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 8 is TEST_VAR_INT_01=123456
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 9 is TEST_VAR_INT_02=123456
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 10 is TEST_VAR_INT_03="0x7FFFFFFF"
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 11 is TEST_VAR_INT_04="0x00000001"
Key 'TEST_VAR_INT_05' not found!
Key 'TEST_VAR_INT_06' not found!
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 12 is TEST_VAR_INT_07=9223372036854775807
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 13 is TEST_VAR_INT_08=9223372036854775807
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 14 is TEST_VAR_INT_09="-9223372036854775808"
Key 'TEST_VAR_INT_10' not found!
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 15 is TEST_VAR_STR_01="\\\\\\\\\\"
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 16 is TEST_VAR_STR_02="\\\\\\\\\\"
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 17 is TEST_VAR_STR_03="\"\"\"\"\"\"\"\"\"\""
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 18 is TEST_VAR_STR_04="\""
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 19 is TEST_VAR_STR_05="\n"
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 21 is TEST_VAR_STR_07="TE\\"ST"
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 22 is TEST_VAR_STR_08="TE\"ST"
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 23 is TEST_VAR_STR_09="TE\\"ST"
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 24 is TEST_VAR_STR_10=123
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 25 is TEST_VAR_STR_11=true
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 26 is TEST_VAR_STR_12="\`cmd\`"
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 27 is TEST_VAR_STR_13="\$HOME"
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 28 is TEST_VAR_STR_14="\$(ls -al)"
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 30 is TEST_VAR_EJS_01=123456
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 31 is TEST_VAR_EJS_02=8
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 32 is TEST_VAR_EJS_03="EJS"
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 33 is TEST_VAR_EJS_04="EJS"
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 34 is TEST_VAR_EJS_05="EJS"
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 35 is TEST_VAR_EJS_06="EJS"
Key 'TEST_VAR_EJS_07' not found!
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 36 is TEST_VAR_EJS_08=true
OK: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN DEBUG shared env pos 37 is TEST_VAR_END="\E\N\D"

---zowe.environments.* expected to be ignored ---

OK: Key '`zowe.environments.-key-`' found: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN WARN Key in zowe.yaml `zowe.environments.-key-` is invalid and it will be ignored
OK: Key '`zowe.environments.?key`' found: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN WARN Key in zowe.yaml `zowe.environments.?key` is invalid and it will be ignored
OK: Key '`zowe.environments.1+1`' found: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN WARN Key in zowe.yaml `zowe.environments.1+1` is invalid and it will be ignored
OK: Key '`zowe.environments.1-1`' found: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN WARN Key in zowe.yaml `zowe.environments.1-1` is invalid and it will be ignored
OK: Key '`zowe.environments._!_`' found: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN WARN Key in zowe.yaml `zowe.environments._!_` is invalid and it will be ignored
OK: Key '`zowe.environments.1TEST`' found: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN WARN Key in zowe.yaml `zowe.environments.1TEST` is invalid and it will be ignored
OK: Key '`zowe.environments.3_141592`' found: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN WARN Key in zowe.yaml `zowe.environments.3_141592` is invalid and it will be ignored
OK: Key '`zowe.environments.()`' found: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN WARN Key in zowe.yaml `zowe.environments.()` is invalid and it will be ignored
OK: Key '`zowe.environments.~null`' found: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN WARN Key in zowe.yaml `zowe.environments.~null` is invalid and it will be ignored
OK: Key '`zowe.environments.=`' found: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN WARN Key in zowe.yaml `zowe.environments.=` is invalid and it will be ignored
OK: Key '`zowe.environments.<h1>`' found: 2026-05-19 07:22:50.213 <ZWELNCH:50660289> MARTIN WARN Key in zowe.yaml `zowe.environments.<h1>` is invalid and it will be ignored
```
