### PR TITLE
Remove "TODO" (fixed in app-server)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -215,10 +215,6 @@ static void set_sys_messages(ConfigManager *configmgr) {
 //size of "ZWE_zowe_sysMessages"
 #define ZWE_ZOWE_SYS_MESSAGES "ZWE_zowe_sysMessages"
 #define ZWE_ZOWE_SYS_MESSAGES_LEN (sizeof(ZWE_ZOWE_SYS_MESSAGES) - 1)
-/* App-server: ZWED5015I prints config as json
-All zowe.sysMessages are printed, e.g. ^      "ZWED0031I",$
-#define ZWED5015I_JSON_CONFIG_EXTRA_CHARACTERS (sizeof("      \"\",") - 1)
-*/
 
 static bool check_match_and_wto_message(const char* sys_message_id, const char* input_string, const bool other_messages) {
 

--- a/src/main.c
+++ b/src/main.c
@@ -234,11 +234,6 @@ static bool check_match_and_wto_message(const char* sys_message_id, const char* 
     if (memcmp(ZWE_ZOWE_SYS_MESSAGES, input_string, ZWE_ZOWE_SYS_MESSAGES_LEN) == 0) {
       return false;
     }
-    /* TODO: Try to ignore messages, which are short and probably output of ZWED5015I
-    if (input_string_len <= strlen(sys_message_id) + ZWED5015I_JSON_CONFIG_EXTRA_CHARACTERS) {
-      return false;
-    }
-    */
   }
 
   if (zl_context.trim_sys_message) {


### PR DESCRIPTION
Once [this](https://github.com/zowe/zlux-app-server/pull/352) is merged, we can remove the commented "TODO" block.

No Changelog update.