### PR TITLE
`PARM 2>&1` to print everything in SYSPRINT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe Launcher package will be documented in this file
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.5.0
-- Enhancement: All error messages are printed to `SYSPRINT` ([#???](https://github.com/zowe/launcher/pull/???))
+- Enhancement: All error messages are printed to `SYSPRINT` ([#177](https://github.com/zowe/launcher/pull/177))
 
 ## 3.4.0
 - Enhancement: Message `ZWEL0021I` includes the version of launcher ([#167](https://github.com/zowe/launcher/pull/167))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zowe Launcher package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 3.5.0
+- Enhancement: All error messages are printed to `SYSPRINT` ([#???](https://github.com/zowe/launcher/pull/???))
+
 ## 3.4.0
 - Enhancement: Message `ZWEL0021I` includes the version of launcher ([#167](https://github.com/zowe/launcher/pull/167))
 

--- a/samplib/ZWESLSTC
+++ b/samplib/ZWESLSTC
@@ -14,14 +14,14 @@
 //* ZOWE LAUNCHER PROCEDURE                                          */
 //*                                                                  */
 //* NOTE: this procedure is a template, you will need to modify      */
-//*       #zowe_yaml variable to point to your Zowe YAML config      */
-//*       file.                                                      */
+//*       {ZWE_CLI_PARAMETER_CONFIG} variable to point to your       */
+//*       Zowe YAML config file.                                     */
 //*                                                                  */
 //* Check https://docs.zowe.org for more details.                    */
 //*                                                                  */
 //********************************************************************/
 //ZWELNCH  EXEC PGM=ZWELNCH,REGION=&RGN,TIME=NOLIMIT,
-// PARM='ENVAR(_CEE_ENVFILE=DD:STDENV),POSIX(ON)/&HAINST.'
+// PARM='ENVAR(_CEE_ENVFILE=DD:STDENV),POSIX(ON)/&HAINST.,/ 2>&1'
 //STEPLIB  DD  DSNAME={zowe.setup.dataset.authLoadlib},
 //             DISP=SHR
 //SYSIN    DD  DUMMY
@@ -29,7 +29,7 @@
 //SYSERR   DD  SYSOUT=*
 //********************************************************************/
 //*
-//* CONFIG= can be either a single path ex.
+//* CONFIG= can be either a single path, for example:
 //*   CONFIG=/my/zowe.yaml
 //*
 //* Or a list of FILE() or PARMLIB() and colon : separated paths


### PR DESCRIPTION
Fixes #176.

All error messages are printed to `SYSPRINT`.

`SYSERR DD` kept, not sure if could be removed.

## Update 03/10/2026

Looks like this will break the HA instances:

```
/S ZWESLSTC,HAINST=LPR1
...
INFO ZWEL0024I HA_INSTANCE_ID is 'lpr1,/'
```

Waiting for #181.