### PR TITLE
Add zowe version print from manifest json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zowe Launcher package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 3.5.0
+- Enhancement: Launcher now prints Zowe's overall version in addition to the Launcher's version ([#179](https://github.com/zowe/launcher/pull/179))
+
 ## 3.4.0
 - Enhancement: Message `ZWEL0021I` includes the version of launcher ([#167](https://github.com/zowe/launcher/pull/167))
 

--- a/src/main.c
+++ b/src/main.c
@@ -1945,14 +1945,13 @@ int main(int argc, char **argv) {
   }
 
   setenv("_BPXK_AUTOCVT", "ON", 1);
-  sprintf(launcherVersion, "%d.%d.%d+%d", LAUNCHER_VERSION_MAJOR, LAUNCHER_VERSION_MINOR, LAUNCHER_VERSION_PATCH, LAUNCHER_VERSION_DATE_STAMP);
-
-  INFO(MSG_LAUNCHER_START, launcherVersion, manifestVersion);
-  INFO(MSG_LINE_LENGTH);
 
   char manifestVersion[64] = {0};
   get_manifest_version(manifestVersion, sizeof(manifestVersion));
-
+  
+  sprintf(launcherVersion, "%d.%d.%d+%d", LAUNCHER_VERSION_MAJOR, LAUNCHER_VERSION_MINOR, LAUNCHER_VERSION_PATCH, LAUNCHER_VERSION_DATE_STAMP);
+  INFO(MSG_LAUNCHER_START, launcherVersion, manifestVersion);
+  INFO(MSG_LINE_LENGTH);
   printf_wto(MSG_LAUNCHER_START, launcherVersion, manifestVersion);
 
   zl_config_t config = read_config(argc, argv);

--- a/src/main.c
+++ b/src/main.c
@@ -1952,7 +1952,7 @@ int main(int argc, char **argv) {
   sprintf(launcherVersion, "%d.%d.%d+%d", LAUNCHER_VERSION_MAJOR, LAUNCHER_VERSION_MINOR, LAUNCHER_VERSION_PATCH, LAUNCHER_VERSION_DATE_STAMP);
   INFO(MSG_LAUNCHER_START, launcherVersion, manifestVersion);
   INFO(MSG_LINE_LENGTH);
-  printf_wto(MSG_LAUNCHER_START, launcherVersion, manifestVersion);
+  printf_wto(MSG_LAUNCHER_START, launcherVersion, manifestVersion);  // Manual sys log print (messages not set here yet)
 
   zl_config_t config = read_config(argc, argv);
   zl_context.config = config;
@@ -1993,8 +1993,6 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 
-
-
   set_sys_messages(configmgr);
 
   //got root dir, can now load up the schemas from it
@@ -2010,7 +2008,6 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 
-  
   set_shared_uss_env(configmgr);
 
   if (process_workspace_dir(configmgr)) {

--- a/src/main.c
+++ b/src/main.c
@@ -1756,6 +1756,38 @@ static int check_root_dir() {
   TODO: resolve template... right now we take the first value for runtimeDirectory we find and assume it to be a path
   TODO: allow parmlib to be the one that has runtimeDirectory. right now a FILE must be found prior to encountering a LIB entry, or the code will attempt an fopen() and fail.
 */
+static void get_manifest_version(char *buf, size_t buf_size) {
+  char manifest_path[PATH_MAX + 1];
+  snprintf(manifest_path, sizeof(manifest_path), "%s/manifest.json", zl_context.root_dir);
+
+  ShortLivedHeap *slh = makeShortLivedHeap(8192, 64);
+  if (!slh) {
+    WARN(MSG_MANIFEST_READ_WARN, "failed to allocate memory");
+    snprintf(buf, buf_size, "unknown");
+    return;
+  }
+
+  char error_buf[256] = {0};
+  Json *manifest_json = jsonParseFile(slh, manifest_path, error_buf, sizeof(error_buf));
+  if (!manifest_json || !jsonIsObject(manifest_json)) {
+    WARN(MSG_MANIFEST_READ_WARN, error_buf[0] ? error_buf : "failed to parse manifest.json");
+    SLHFree(slh);
+    snprintf(buf, buf_size, "unknown");
+    return;
+  }
+
+  JsonObject *manifest_root = jsonAsObject(manifest_json);
+  char *manifest_version = jsonObjectGetString(manifest_root, "version");
+  if (manifest_version) {
+    snprintf(buf, buf_size, "%s", manifest_version);
+  } else {
+    WARN(MSG_MANIFEST_READ_WARN, "version field not found in manifest.json");
+    snprintf(buf, buf_size, "unknown");
+  }
+
+  SLHFree(slh);
+}
+
 static int process_root_dir(ConfigManager *configmgr) {
   int getStatus = cfgGetStringC(configmgr, ZOWE_CONFIG_NAME, &zl_context.root_dir, 2, "zowe", "runtimeDirectory");
   if (getStatus) {
@@ -1914,9 +1946,14 @@ int main(int argc, char **argv) {
 
   setenv("_BPXK_AUTOCVT", "ON", 1);
   sprintf(launcherVersion, "%d.%d.%d+%d", LAUNCHER_VERSION_MAJOR, LAUNCHER_VERSION_MINOR, LAUNCHER_VERSION_PATCH, LAUNCHER_VERSION_DATE_STAMP);
-  INFO(MSG_LAUNCHER_START, launcherVersion);
+
+  INFO(MSG_LAUNCHER_START, launcherVersion, manifestVersion);
   INFO(MSG_LINE_LENGTH);
-  printf_wto(MSG_LAUNCHER_START, launcherVersion); // Manual sys log print (messages not set here yet)
+
+  char manifestVersion[64] = {0};
+  get_manifest_version(manifestVersion, sizeof(manifestVersion));
+
+  printf_wto(MSG_LAUNCHER_START, launcherVersion, manifestVersion);
 
   zl_config_t config = read_config(argc, argv);
   zl_context.config = config;
@@ -1956,7 +1993,9 @@ int main(int argc, char **argv) {
   if (process_root_dir(configmgr)) {
     exit(EXIT_FAILURE);
   }
-  
+
+
+
   set_sys_messages(configmgr);
 
   //got root dir, can now load up the schemas from it

--- a/src/main.c
+++ b/src/main.c
@@ -1946,6 +1946,9 @@ int main(int argc, char **argv) {
 
   setenv("_BPXK_AUTOCVT", "ON", 1);
 
+  zl_config_t config = read_config(argc, argv);
+  zl_context.config = config;
+
   char manifestVersion[64] = {0};
   get_manifest_version(manifestVersion, sizeof(manifestVersion));
   
@@ -1953,9 +1956,6 @@ int main(int argc, char **argv) {
   INFO(MSG_LAUNCHER_START, launcherVersion, manifestVersion);
   INFO(MSG_LINE_LENGTH);
   printf_wto(MSG_LAUNCHER_START, launcherVersion, manifestVersion);  // Manual sys log print (messages not set here yet)
-
-  zl_config_t config = read_config(argc, argv);
-  zl_context.config = config;
 
   LoggingContext *logContext = makeLoggingContext();
   if (!logContext) {

--- a/src/msg.h
+++ b/src/msg.h
@@ -33,7 +33,7 @@
 #define MSG_INST_PREPARED       MSG_PREFIX "0018I" " Zowe instance prepared successfully\n"
 #define MSG_LAUNCHER_STOPING    MSG_PREFIX "0019I" " Zowe Launcher stopping\n"
 #define MSG_LOADING_YAML        MSG_PREFIX "0020I" " loading '%s'\n"
-#define MSG_LAUNCHER_START      MSG_PREFIX "0021I" " Zowe Launcher starting, version is %s\n"
+#define MSG_LAUNCHER_START      MSG_PREFIX "0021I" " Zowe Launcher starting, Launcher version %s, Zowe version %s\n"
 #define MSG_LAUNCHER_STOPPED    MSG_PREFIX "0022I" " Zowe Launcher stopped\n"
 #define MSG_YAML_FILE           MSG_PREFIX "0023I" " Zowe YAML config file is \'%s\'\n"
 #define MSG_HA_INST_ID          MSG_PREFIX "0024I" " HA_INSTANCE_ID is '%s'\n"
@@ -87,6 +87,7 @@
 #define MSG_CFG_LOAD_FAIL       MSG_PREFIX "0072E" " Launcher Could not load configurations\n"
 #define MSG_CFG_SCHEMA_FAIL     MSG_PREFIX "0073E" " Launcher Could not load schemas, status=%d\n"
 #define MSG_NO_LOG_CONTEXT      MSG_PREFIX "0074E" " Log context was not created\n"
+#define MSG_MANIFEST_READ_WARN  MSG_PREFIX "0076W" " Could not read manifest.json version: %s\n"
 #define MSG_LINE_LENGTH         "-- If you cant see '500' at the end of the line, your log is too short to read!80--------90------ 100----------------------125----------------------150----------------------175----------------------200----------------------225----------------------250----------------------275----------------------300----------------------325----------------------350----------------------375----------------------400----------------------425----------------------450----------------------475----------------------500\n"
 
 #endif // MSG_H

--- a/src/msg.h
+++ b/src/msg.h
@@ -87,7 +87,7 @@
 #define MSG_CFG_LOAD_FAIL       MSG_PREFIX "0072E" " Launcher Could not load configurations\n"
 #define MSG_CFG_SCHEMA_FAIL     MSG_PREFIX "0073E" " Launcher Could not load schemas, status=%d\n"
 #define MSG_NO_LOG_CONTEXT      MSG_PREFIX "0074E" " Log context was not created\n"
-#define MSG_MANIFEST_READ_WARN  MSG_PREFIX "0076W" " Could not read manifest.json version: %s\n"
+#define MSG_MANIFEST_READ_WARN  MSG_PREFIX "0075W" " Could not read manifest.json version: %s\n"
 #define MSG_LINE_LENGTH         "-- If you cant see '500' at the end of the line, your log is too short to read!80--------90------ 100----------------------125----------------------150----------------------175----------------------200----------------------225----------------------250----------------------275----------------------300----------------------325----------------------350----------------------375----------------------400----------------------425----------------------450----------------------475----------------------500\n"
 
 #endif // MSG_H
@@ -361,10 +361,10 @@
 //@
 //@  No action required.
 //@
-// #define MSG_LAUNCHER_START      MSG_PREFIX "0021I" " Zowe Launcher starting\n"
+// #define MSG_LAUNCHER_START      MSG_PREFIX "0021I" " Zowe Launcher starting, Launcher version %s, Zowe version %s\n"
 //@### ZWEL0021I
 //@
-//@  Zowe Launcher starting
+//@  Zowe Launcher starting, Launcher version %s, Zowe version %s
 //@
 //@  **Reason:**
 //@
@@ -1072,6 +1072,23 @@
 //@
 //@  No action required.
 //@
+// #define MSG_CMD_RCP_WARN        MSG_PREFIX "0075W" " Could not read manifest.json version: %s\n"
+//@### ZWEL0075W
+//@
+//@  Could not read manifest.json version: %s
+//@
+//@  **Reason:**
+//@
+//@  The manifest.json file within the Zowe runtime was unreadable for the reason stated in `<reason>`.
+//@  The version will be printed as 'unknown'.
+//@
+//@  **Action:**
+//@
+//@  Verify that the runtime directory is unaltered, has necessary read permissions for the Zowe STC
+//@  And has not become corrupt in some way.
+//@
+
+
 
 /*
   This program and the accompanying materials are


### PR DESCRIPTION
This PR modifies message ZWEL0021I to include Zowe's release version to prevent user confusion in the case that launcher does not get updated with patch-only releases.

This just uses manifest.json within the workspace. It reads it using zowe-common-c json library.