### PR TITLE
Check if HA name is followed by another parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zowe Launcher package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
-## 3.5.0
+## 3.6.0
 - Bugfix: Check the HA instance name if followed by any additional parameters ([#181](https://github.com/zowe/launcher/pull/181))
 
 ## 3.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zowe Launcher package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 3.5.0
+- Bugfix: Check the HA instance name if followed by any additional parameters ([#181](https://github.com/zowe/launcher/pull/181))
+
 ## 3.4.0
 - Enhancement: Message `ZWEL0021I` includes the version of launcher ([#167](https://github.com/zowe/launcher/pull/167))
 

--- a/src/main.c
+++ b/src/main.c
@@ -643,6 +643,12 @@ static int init_context(int argc, char **argv, const struct zl_config_t *cfg, Co
   }
   snprintf (zl_context.ha_instance_id, sizeof(zl_context.ha_instance_id), "%s", argv[1]);
   to_lower(zl_context.ha_instance_id);
+  for (int i = 0; i < strlen(zl_context.ha_instance_id); i++) {
+    if (zl_context.ha_instance_id[i] == ',') {
+      zl_context.ha_instance_id[i] = 0;
+      break;
+    }
+  }
   INFO(MSG_HA_INST_ID, zl_context.ha_instance_id);
 
   if (pthread_cond_init(&zl_context.event_cv, NULL) != 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -642,13 +642,13 @@ static int init_context(int argc, char **argv, const struct zl_config_t *cfg, Co
     return -1;
   }
   snprintf (zl_context.ha_instance_id, sizeof(zl_context.ha_instance_id), "%s", argv[1]);
-  to_lower(zl_context.ha_instance_id);
   for (int i = 0; i < strlen(zl_context.ha_instance_id); i++) {
     if (zl_context.ha_instance_id[i] == ',') {
       zl_context.ha_instance_id[i] = 0;
       break;
     }
   }
+  to_lower(zl_context.ha_instance_id);
   INFO(MSG_HA_INST_ID, zl_context.ha_instance_id);
 
   if (pthread_cond_init(&zl_context.event_cv, NULL) != 0) {

--- a/test/config-syntax.sh
+++ b/test/config-syntax.sh
@@ -95,6 +95,7 @@ PARMLIB(ZOWE.TEST-1.A(A)) | hello | ZWEL0023I Zowe YAML config file is 'PARMLIB(
 PARMLIB(ZOWE.TEST-1.A) | world | ZWEL0068E PARMLIB() entries must have a member name | Should detect missing member
 PARMLIB(ZOWE.TEST-1.A() | | ZWEL0068E PARMLIB() entries must have a member name | Should detect missing member
 PARMLIB(ZOWE.TEST-1.A()) | | ZWEL0068E PARMLIB() entries must have a member name | Should detect missing member
+${ABS_ZOWE} | valid,IGNORED | ZWEL0024I HA_INSTANCE_ID is 'valid' | Should ignore the second parameter
 EOF
 
 exit $errors


### PR DESCRIPTION
Fixes #180 

## Unit test added, 2 parameters used as HA:
```
haInstance=valid,IGNORED
2026-03-23 11:00:43.512 <ZWELNCH:50659618> MARTIN INFO ZWEL0024I HA_INSTANCE_ID is 'valid'
```

## STC test

STC modified with additional parmeter:

```jcl
//ZWELNCH  EXEC PGM=ZWELNCH,REGION=&RGN,TIME=NOLIMIT,            
// PARM='ENVAR(_CEE_ENVFILE=DD:STDENV),POSIX(ON)/&HAINST.,/ 2>&1'
```

```
/S ZWESLSTC,HAINST=TEST
ZWESVUSR INFO ZWEL0024I HA_INSTANCE_ID is 'test'
```

```
/S ZWESLSTC,HAINST='TEST,HELLO'
ZWESVUSR INFO ZWEL0024I HA_INSTANCE_ID is 'test'
```