### PR TITLE
Optional flags for xlclang

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -58,6 +58,7 @@ echo "Compiling qascii libyaml \"${LIBYAML_BRANCH}\" and quickjs \"${QUICKJS_BRA
 
 xlclang \
   -c \
+  ${ZWE_XLCLANG_FLAGS} \
   -q64 \
   -qascii \
   "-Wc,float(ieee),longname,langlvl(extc99),gonum,goff,ASM,asmlib('CEE.SCEEMAC','SYS1.MACLIB','SYS1.MODGEN')" \
@@ -108,6 +109,7 @@ fi
 echo "Compiling zowe_launcher ${LAUNCHER_MAJOR}.${LAUNCHER_MINOR}.${LAUNCHER_PATCH}+${launcher_date_stamp}"
 
 xlclang \
+  ${ZWE_XLCLANG_FLAGS} \
   -q64 \
   "-Wa,goff" \
   "-Wc,float(ieee),langlvl(extc99),agg,list()" \


### PR DESCRIPTION
This PR adds env var ZWE_XLCLANG_FLAGS in the compile for xlclang, so that if you have environmental needs different from others, you can just set that during your compiles.

In particular, I was using this to add the -F flag.