### PR TITLE
`zowe.launcher.restartIntervals`: use only `ZL_INT_ARRAY_CAPACITY` items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe Launcher package will be documented in this file
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.6.0
-- Bugfix: Check the array size of `zowe.launcher.restartIntervals` ([#???](https://github.com/zowe/launcher/pull/???))
+- Bugfix: Check the array size of `zowe.launcher.restartIntervals` ([#187](https://github.com/zowe/launcher/pull/187))
 
 ## 3.4.0
 - Enhancement: Message `ZWEL0021I` includes the version of launcher ([#167](https://github.com/zowe/launcher/pull/167))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zowe Launcher package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 3.6.0
+- Bugfix: Check the array size of `zowe.launcher.restartIntervals` ([#???](https://github.com/zowe/launcher/pull/???))
+
 ## 3.4.0
 - Enhancement: Message `ZWEL0021I` includes the version of launcher ([#167](https://github.com/zowe/launcher/pull/167))
 

--- a/src/main.c
+++ b/src/main.c
@@ -706,8 +706,8 @@ static void init_component_restart_intervals(zl_comp_t *comp, ConfigManager *con
   JsonArray *intArray = jsonAsArray(restartIntArray);
   int count = jsonArrayGetCount(intArray);
   if (count > ZL_INT_ARRAY_CAPACITY) {
-    count = ZL_INT_ARRAY_CAPACITY;
     DEBUG("zowe.launcher.restartIntervals: %d out of %d will be used.", ZL_INT_ARRAY_CAPACITY, count);
+    count = ZL_INT_ARRAY_CAPACITY;
   }
   comp->restart_intervals.count = count;
   for (int i = 0; i < count; i++) {

--- a/src/main.c
+++ b/src/main.c
@@ -705,6 +705,10 @@ static void init_component_restart_intervals(zl_comp_t *comp, ConfigManager *con
   // load restartIntervals from the configuration
   JsonArray *intArray = jsonAsArray(restartIntArray);
   int count = jsonArrayGetCount(intArray);
+  if (count > ZL_INT_ARRAY_CAPACITY) {
+    count = ZL_INT_ARRAY_CAPACITY;
+    DEBUG("zowe.launcher.restartIntervals: %d out of %d will be used.", ZL_INT_ARRAY_CAPACITY, count);
+  }
   comp->restart_intervals.count = count;
   for (int i = 0; i < count; i++) {
     comp->restart_intervals.data[i] = jsonArrayGetNumber(intArray, i);

--- a/src/main.c
+++ b/src/main.c
@@ -706,7 +706,7 @@ static void init_component_restart_intervals(zl_comp_t *comp, ConfigManager *con
   JsonArray *intArray = jsonAsArray(restartIntArray);
   int count = jsonArrayGetCount(intArray);
   if (count > ZL_INT_ARRAY_CAPACITY) {
-    DEBUG("zowe.launcher.restartIntervals: %d out of %d will be used.", ZL_INT_ARRAY_CAPACITY, count);
+    DEBUG("zowe.launcher.restartIntervals: %d out of %d will be used.\n", ZL_INT_ARRAY_CAPACITY, count);
     count = ZL_INT_ARRAY_CAPACITY;
   }
   comp->restart_intervals.count = count;


### PR DESCRIPTION
```yaml
zowe:
  launcher:
    restartIntervals:
      - 1
      - 2
      - 3
      # ....
      - 1022
      - 1023
      - 1024
```

The internal structure stores `ZL_INT_ARRAY_CAPACITY` items (100 at this moment). More items will cause unpredictable errors. 

## With fix
The first 100 intervals is stored and launcher continues.
```
2026-05-06 06:33:36.844 <ZWELNCH:50659712> ZWESVUSR
DEBUG zowe.launcher.restartIntervals: 100 out of 1024 will be used.
```