### PR TITLE
Use `wtoMessage` (almost) directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zowe Launcher package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 3.6.0
+- Bugfix: Use `wtoMessage` directly when the message is triggered from `zowe.sysMessages` ([#189](https://github.com/zowe/launcher/pull/189))
+
 ## 3.4.0
 - Enhancement: Message `ZWEL0021I` includes the version of launcher ([#167](https://github.com/zowe/launcher/pull/167))
 

--- a/src/main.c
+++ b/src/main.c
@@ -260,22 +260,22 @@ static bool check_match_and_wto_message(const char* sys_message_id, const char* 
   }
 
   if (zl_context.trim_sys_message) {
-    wtoMessage(input_string + sys_message_pos);
+    wtoPrintf3(input_string + sys_message_pos);
   } else {
     // Short message, WTO *
     if (input_string_len <= WTO_MESSAGE_LENGTH) {
-      wtoMessage(input_string);
+      wtoPrintf3(input_string);
     // Message length > WTO_MESSAGE_LENGTH
     } else {
       // After the match, there are more chars than WTO_MESSAGE_LENGTH
       // WTO from match position
       if (input_string_len - sys_message_pos > WTO_MESSAGE_LENGTH) {
-        wtoMessage(input_string + sys_message_pos);
+        wtoPrintf3(input_string + sys_message_pos);
       } else {
         // The match is in the last WTO_MESSAGE_LENGTH chars
         // WTO last WTO_MESSAGE_LENGTH chars - egde case: if the match is last word
         //   user will see the text before match too
-        wtoMessage(input_string + (input_string_len - WTO_MESSAGE_LENGTH));
+        wtoPrintf3(input_string + (input_string_len - WTO_MESSAGE_LENGTH));
       }
     }
   }

--- a/src/main.c
+++ b/src/main.c
@@ -260,22 +260,22 @@ static bool check_match_and_wto_message(const char* sys_message_id, const char* 
   }
 
   if (zl_context.trim_sys_message) {
-    printf_wto(input_string + sys_message_pos);
+    wtoMessage(input_string + sys_message_pos);
   } else {
     // Short message, WTO *
     if (input_string_len <= WTO_MESSAGE_LENGTH) {
-      printf_wto(input_string);
+      wtoMessage(input_string);
     // Message length > WTO_MESSAGE_LENGTH
     } else {
       // After the match, there are more chars than WTO_MESSAGE_LENGTH
       // WTO from match position
       if (input_string_len - sys_message_pos > WTO_MESSAGE_LENGTH) {
-        printf_wto(input_string + sys_message_pos);
+        wtoMessage(input_string + sys_message_pos);
       } else {
         // The match is in the last WTO_MESSAGE_LENGTH chars
         // WTO last WTO_MESSAGE_LENGTH chars - egde case: if the match is last word
         //   user will see the text before match too
-        printf_wto(input_string + (input_string_len - WTO_MESSAGE_LENGTH));
+        wtoMessage(input_string + (input_string_len - WTO_MESSAGE_LENGTH));
       }
     }
   }

--- a/src/main.c
+++ b/src/main.c
@@ -210,12 +210,34 @@ struct {
 // Forward declarations
 static void comp_log(zl_comp_t *comp, char *msg);
 
-// Wrapper for wtoPrintf3
+// Wrapper for wtoPrintf3 - WTO message with C formatting specifiers
 static void printf_wto(const char *formatString, ...) {
   va_list argPointer;
   va_start(argPointer, formatString);
   wtoPrintf3(formatString, argPointer);
   va_end(argPointer);
+}
+
+// WTO message ignoring C formatting specifiers, the first new line stops the message and the rest is ignored.
+// print_wto_directly("%s%i%d\n\n") -> WTO "%s%i%d"
+static void print_wto_directly(const char *wtoMessage) {
+  if (wtoMessage == NULL) return;
+
+  size_t len = strlen(wtoMessage);
+  char *wtoCopy = malloc(len + 1);
+  if (wtoCopy == NULL) return;
+
+  memcpy(wtoCopy, wtoMessage, len + 1);
+
+  for (size_t i = 0; i < len; i++) {
+    if (wtoCopy[i] == '\n') {
+      wtoCopy[i] = '\0';
+      break;
+    }
+  }
+
+  wtoMessage(wtoCopy);
+  free(wtoCopy);
 }
 
 static void set_sys_messages(ConfigManager *configmgr) {
@@ -260,22 +282,22 @@ static bool check_match_and_wto_message(const char* sys_message_id, const char* 
   }
 
   if (zl_context.trim_sys_message) {
-    wtoPrintf3(input_string + sys_message_pos);
+    print_wto_directly(input_string + sys_message_pos);
   } else {
     // Short message, WTO *
     if (input_string_len <= WTO_MESSAGE_LENGTH) {
-      wtoPrintf3(input_string);
+      print_wto_directly(input_string);
     // Message length > WTO_MESSAGE_LENGTH
     } else {
       // After the match, there are more chars than WTO_MESSAGE_LENGTH
       // WTO from match position
       if (input_string_len - sys_message_pos > WTO_MESSAGE_LENGTH) {
-        wtoPrintf3(input_string + sys_message_pos);
+        print_wto_directly(input_string + sys_message_pos);
       } else {
         // The match is in the last WTO_MESSAGE_LENGTH chars
         // WTO last WTO_MESSAGE_LENGTH chars - egde case: if the match is last word
         //   user will see the text before match too
-        wtoPrintf3(input_string + (input_string_len - WTO_MESSAGE_LENGTH));
+        print_wto_directly(input_string + (input_string_len - WTO_MESSAGE_LENGTH));
       }
     }
   }

--- a/src/main.c
+++ b/src/main.c
@@ -220,24 +220,24 @@ static void printf_wto(const char *formatString, ...) {
 
 // WTO message ignoring C formatting specifiers, the first new line stops the message and the rest is ignored.
 // print_wto_directly("%s%i%d\n\n") -> WTO "%s%i%d"
-static void print_wto_directly(const char *wtoMessage) {
-  if (wtoMessage == NULL) return;
+static void print_wto_directly(const char *wtoText) {
+  if (wtoText == NULL) return;
 
-  size_t len = strlen(wtoMessage);
-  char *wtoCopy = malloc(len + 1);
-  if (wtoCopy == NULL) return;
+  size_t len = strlen(wtoText);
+  char *wtoTextCopy = malloc(len + 1);
+  if (wtoTextCopy == NULL) return;
 
-  memcpy(wtoCopy, wtoMessage, len + 1);
+  memcpy(wtoTextCopy, wtoText, len + 1);
 
   for (size_t i = 0; i < len; i++) {
-    if (wtoCopy[i] == '\n') {
-      wtoCopy[i] = '\0';
+    if (wtoTextCopy[i] == '\n') {
+      wtoTextCopy[i] = '\0';
       break;
     }
   }
 
-  wtoMessage(wtoCopy);
-  free(wtoCopy);
+  wtoMessage(wtoTextCopy);
+  free(wtoTextCopy);
 }
 
 static void set_sys_messages(ConfigManager *configmgr) {


### PR DESCRIPTION
When the `zowe.sysMessages` is triggered and the message contains C formatting specifier(s), it can print unpredictable result or abend.

Example:
```
* ZWEL1234I is defined in zowe.sysMessages and triggered for WTO
ZWEL1234I The usage is 80%see example.com for more details.
                          ^
                          +-- Missing space creates formatting specifier %s,
                          but string argument is not provided
                          as the message is expected to be a "simple string" for WTO.
```

## Common setting

```yaml
zowe:
  sysMessages:
    # the default messages from example-zowe used
    - "ZWEL9999"
```

`internal start prepare` contains this testing message:
```javascript
console.log("ZWEL9999 %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s");
```

## Without fix
```
CEE3204S The system detected a protection exception (System Completion Code=0C4).
         From compile unit ZZOW11:/ZOWE/tmp/pax-packaging-launcher-1776868548042/content/build/../deps/launcher/common/c/zos.c at
         entry point wtoPrintf3 at statement 1520 at compile unit offset +000000003BFEBBB0 at entry offset +0000000000000058 at
         address 000000003BFEBBB0.
```
`wtoPrintf3` tries to use arguments, which are not provided.

## With fix

### Why so complicated?
* `wtoMessage` does not handle new line character
*  `wtoPrintf3` handles new line character, but expecting arguments for C formatting specifies
* There is a new wrapper in launcher `print_wto_directly` to handle new line and does not care about C formatting specifies

Message in the log:
```
ZWEL9999 %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s
```

Message triggered and print with WTO:
```
ZWEL0021I Zowe Launcher starting, version is 3.6.0+20260513          
ZWEL9999 %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s
ZWEL0018I Zowe instance prepared successfully                        
```

## `example-zowe.yaml`
There is this hint in `example-zowe.yaml` for `zowe.sysMessages`
> Not limited to Zowe message IDs, you can specify your own string for example:
>   "ERROR"

With the general word and debug options enabled, there is a possibility that messages containing C formatting specifiers may be generated unintentionally.