### PR TITLE
Stop component: do not `fclose(null)`

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1351,11 +1351,11 @@ static int stop_components(void) {
       }
       rc = -1;
     }
-    if (comp->log_file) {
-      if (fclose(comp->log_file)) {
+    if (compkill->log_file) {
+      if (fclose(compkill->log_file)) {
         ERROR("fclose() failed for %s - %s\n", comp->name, strerror(errno));
       } else {
-        comp->log_file = 0;
+        compkill->log_file = 0;
       }
     }
   }

--- a/src/main.c
+++ b/src/main.c
@@ -1351,10 +1351,12 @@ static int stop_components(void) {
       }
       rc = -1;
     }
-    if (fclose(compkill->log_file)) {
-      ERROR("fclose() failed for %s - %s\n", compkill->name, strerror(errno));
-    } else {
-      compkill->log_file = 0;
+    if (comp->log_file) {
+      if (fclose(comp->log_file)) {
+        ERROR("fclose() failed for %s - %s\n", comp->name, strerror(errno));
+      } else {
+        comp->log_file = 0;
+      }
     }
   }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1353,7 +1353,7 @@ static int stop_components(void) {
     }
     if (compkill->log_file) {
       if (fclose(compkill->log_file)) {
-        ERROR("fclose() failed for %s - %s\n", comp->name, strerror(errno));
+        ERROR("fclose() failed for %s - %s\n", compkill->name, strerror(errno));
       } else {
         compkill->log_file = 0;
       }


### PR DESCRIPTION
When the component is killed, close only existing log file - if the log file was not created/used, do not try to close file pointer zero.

**Notes:**
* No changelog update
* Only V3