### PR TITLE
Check `comp_list` boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zowe Launcher package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 3.6.0
+- Bugfix: Component names must fit the component list ([#195](https://github.com/zowe/launcher/pull/195))
+
 ## 3.5.0
 - Bugfix: Escape backslash, backtick and dollar sign when used in environment variable ([#168](https://github.com/zowe/launcher/pull/168))
 - Bugfix: Check the array size of `zowe.launcher.restartIntervals` ([#187](https://github.com/zowe/launcher/pull/187))

--- a/src/main.c
+++ b/src/main.c
@@ -1949,7 +1949,7 @@ static int get_component_list(char *buf, size_t buf_size,ConfigManager *configmg
               strncpy(comp_list + len + strlen(prop->key), ",", 1);
               len += (strlen(prop->key)+1);
             } else {
-              DEBUG("skip adding of component %s to comp_list[%d/%zu]\n", prop->key, len, sizeof(comp_list));
+              DEBUG("skip adding component %s to comp_list\n", prop->key);
             }
           }
         }

--- a/src/main.c
+++ b/src/main.c
@@ -1944,9 +1944,13 @@ static int get_component_list(char *buf, size_t buf_size,ConfigManager *configmg
               startScript = true;
           }
           if (startScript) {
-            strncpy(comp_list + len, prop->key, strlen(prop->key));
-            strncpy(comp_list + len + strlen(prop->key), ",", 1);
-            len += (strlen(prop->key)+1);
+            if (len + strlen(prop->key) + 2 <= sizeof(comp_list)) {
+              strncpy(comp_list + len, prop->key, strlen(prop->key));
+              strncpy(comp_list + len + strlen(prop->key), ",", 1);
+              len += (strlen(prop->key)+1);
+            } else {
+              DEBUG("skip adding of component %s to comp_list[%d/%zu]\n", prop->key, len, sizeof(comp_list));
+            }
           }
         }
       }


### PR DESCRIPTION
## Problem
* if too many components defined
* `comp_list` is defined with specific size
* component names are added to the list without check
* the last component could be in malformed

```
ZWEL0006I starting components
ZWEL0001I component yyyyyyyyyyyyyyyyyyyyyyyyyyyyy00 started
ZWEL0001I component yyyyyyyyyyyyyyyyyyyyyyyyyyyyy01 started
ZWEL0001I component yyyyyyyyyyyyyyyyyyyyyyyyyyyyy02 started
...
ZWEL0001I component yyyyyyyyyyyyyyyyyyyyyyyyyyyyy31 started
ZWEL0001I component yyyyyyyyyy started  <- Should be yyyyyyyyyyyyyyyyyyyyyyyyyyyyy32
ZWEL0007I components started
```

## To discuss
* This fix just prints debug message (who will define so many components, that the names will not fit into 1kB buffer?)
* **Should we print error and quit?**