### PR TITLE
also run check_messages on push (v3.x branches)

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -115,7 +115,7 @@ jobs:
           fi
 
   check-messages:
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Fixes build-test so the build step always runs on push to `v3.x` branches (e.g. when PRs are merged). 

`check_messages` is a pre-req to the build step, and was not being run on `push` events.